### PR TITLE
Pre release Benchmarks v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ To get started with these VLSI benchmarks, you can proceed in two ways:
 ---
 ## Citation
 
-If you use this framework in your research, please cite the following publication:
+If you use this framework in your research, please cite the following publication (not yet available in IEEExplorer, to be presented at [IEEE ETS 2026](https://ets2026.uniwa.gr/conference-program/)):
 
 ```
 @INPROCEEDINGS{benchmarks,
   author={Angione, Francesco and Bernardi, Paolo and di Gruttola Giardino, Nicola and Filipponi, Gabriele and Iaria, Giusy and Perlo, Giacomo and Pomeranz, Irith and Porsia, Antonio and Ruospo, Annachiara and Sanchez, Ernesto and Turco, Vittorio},
-  booktitle={To appear in the proocedings of 2026 IEEE European Test Symposium (ETS)}, 
+  booktitle={2026 IEEE European Test Symposium (ETS)}, 
   title={Advances in Testing and Reliability Benchmarks}, 
   year={2026},
   volume={},
@@ -94,6 +94,6 @@ series = {DAC '22}
 Feel free to contribute with issues, PRs.
 You can contact us at:
 - Francesco Angione (francesco.angione@polito.it)
-- Nicola di Gruttola giardino (nicola,.digruttola@polito.it)
+- Nicola di Gruttola Giardino (nicola.digruttola@polito.it)
 - Gabriele Filipponi (gabriele.filipponi@polito.it)
 - Giusy Iaria (giusy.iaria@polito.it)

--- a/README.md
+++ b/README.md
@@ -1,46 +1,60 @@
 ![CHIPYARD](https://github.com/ucb-bar/chipyard/raw/main/docs/_static/images/chipyard-logo-full.png)
+![CAD](https://raw.githubusercontent.com/cad-polito-it/.github/refs/heads/main/profile/cad.png)
 
-<h1><span style="color:red;">Please see for VLSI benchmarks <a href="/README_cad.md">README_cad.md</a></span></h1>
+# VLSI Benchmarks for Hardware Testing
+
+![Status](https://img.shields.io/badge/Status-Research--Prototype-orange.svg)
+
+This repository implements a playground for an **Agile Framework for Prototyping Hardware Testing Structural and Functional Methodologies**. 
+
+It leverages the [Chipyard](https://github.com/ucb-bar/chipyard) ecosystem and extends the [HAMMER](https://github.com/ucb-bar/hammer) VLSI flow. This repository is a fork of the main Chipyard and Hammer repositories (please see the Chipyard [README](https://github.com/cad-polito-it/chipyard/blob/working/cad_servers/README_chipyard.md) for further details).
+
+---
+
+## Overview
+As modern silicon devices increase in complexity, traditional benchmarks (ISCAS-85, ITC-99, etc.) are becoming insufficient. Furthermore, test engineers often spend excessive time manually adapting EDA-dependent scripts, which is error-prone and inefficient.
+
+This framework provides an **Unified Hardware Testing Support** for both **Structural** and **Functional** testing:
+* **Modern Benchmarks:** Access to complex, open-source SoC designs (Rocket Chip, BOOM, hardware accelerators) via Chipyard.
+* **Agile VLSI Flow:** Automation and abstraction of EDA tool-dependent commands using Python-based wrappers in Hammer.
+
+The framework is built on two primary pillars:
+
+1. **Chipyard:** Handles system-to-RTL design. It provides a library of ready-to-use IPs, including in-order/out-of-order processors, vector processors, and various interconnects.
+2. **Hammer (Highly Agile Masks Made Effortlessly from RTL):** Handles the RTL-to-physical design flow. The following steps have been introduced for hardware testing, covering different fault models (Stuck-at faults, Transition Delay faults, Small Delay faults, Transient faults):
+    * **DfT Insertion:** Automated Design-for-Testability (scan chain insertion) during the synthesis phase.
+    * **ATPG Flow:** A dedicated Automatic Test Pattern Generation infrastructure.
+    * **Functional Fault Simulation:** Evaluation of firmware-based tests through a specialized infrastructure.
+
+> **NOTE:** This framework aims to allow researchers to focus on testing methodologies rather than "bug-hunting" in adapted scripts and "benchmark-hunting".
+
+---
+
+## Getting Started
+
+To get started with these VLSI benchmarks, you can proceed in two ways:
+* **Full Setup:** If you are ready to dive in, please visit this [README](https://github.com/cad-polito-it/chipyard/blob/working/cad_servers/README_cad.md) for a comprehensive guide on installing the framework and using the various steps. Both Structural and Functional testing flows are supported.
+* **Pre-synthesized Benchmarks:** If you would like to use your existing workspace, you can find a set of synthesized benchmarks [here](https://github.com/cad-polito-it/chipyard/releases). For logic simulation of existing released benchmarks, you will need to set up your own simulation infrastructure.
+
+---
+## Citation
+
+If you use this framework in your research, please cite the following publication:
+
+```
+@INPROCEEDINGS{benchmarks,
+  author={Angione, Francesco and Bernardi, Paolo and di Gruttola Giardino, Nicola and Filipponi, Gabriele and Iaria, Giusy and Perlo, Giacomo and Pomeranz, Irith and Porsia, Antonio and Ruospo, Annachiara and Sanchez, Ernesto and Turco, Vittorio},
+  booktitle={To appear in the proocedings of 2026 IEEE European Test Symposium (ETS)}, 
+  title={Advances in Testing and Reliability Benchmarks}, 
+  year={2026},
+  volume={},
+  number={},
+  pages={1-10},
+  }
+```
 
 
-# Chipyard Framework [![Test](https://github.com/ucb-bar/chipyard/actions/workflows/chipyard-run-tests.yml/badge.svg)](https://github.com/ucb-bar/chipyard/actions)
-
-## Quick Links
-
-* **Latest Documentation**: https://chipyard.readthedocs.io/
-* **User Question Forum**: https://groups.google.com/forum/#!forum/chipyard
-* **Bugs and Feature Requests**: https://github.com/ucb-bar/chipyard/issues
-
-## Using Chipyard
-
-To get started using Chipyard, see the documentation on the Chipyard documentation site: https://chipyard.readthedocs.io/
-
-## What is Chipyard
-
-Chipyard is an open source framework for agile development of Chisel-based systems-on-chip.
-It will allow you to leverage the Chisel HDL, Rocket Chip SoC generator, and other [Berkeley][berkeley] projects to produce a [RISC-V][riscv] SoC with everything from MMIO-mapped peripherals to custom accelerators.
-Chipyard contains processor cores ([Rocket][rocket-chip], [BOOM][boom], [CVA6 (Ariane)][cva6]), vector units ([Saturn][saturn], [Ara][ara]), accelerators ([Gemmini][gemmini], [NVDLA][nvdla]), memory systems, and additional peripherals and tooling to help create a full featured SoC.
-Chipyard supports multiple concurrent flows of agile hardware development, including software RTL simulation, FPGA-accelerated simulation ([FireSim][firesim]), automated VLSI flows ([Hammer][hammer]), and software workload generation for bare-metal and Linux-based systems ([FireMarshal][firemarshal]).
-Chipyard is actively developed in the [Berkeley Architecture Research Group][ucb-bar] in the [Electrical Engineering and Computer Sciences Department][eecs] at the [University of California, Berkeley][berkeley].
-
-## Resources
-
-* Chipyard Documentation: https://chipyard.readthedocs.io/
-* Chipyard (x FireSim) Tutorial: https://fires.im/tutorial-recent/
-* Chipyard Basics slides: https://fires.im/asplos23-slides-pdf/02_chipyard_basics.pdf
-
-## Need help?
-
-* Join the Chipyard Mailing List: https://groups.google.com/forum/#!forum/chipyard
-* If you find a bug or would like propose a feature, post an issue on this repo: https://github.com/ucb-bar/chipyard/issues
-
-## Contributing
-
-* See [CONTRIBUTING.md](/CONTRIBUTING.md)
-
-## Attribution and Chipyard-related Publications
-
-If used for research, please cite Chipyard by the following publication:
+If used for research, please cite Chipyard and Hammer by the following publications:
 
 ```
 @article{chipyard,
@@ -56,50 +70,30 @@ If used for research, please cite Chipyard by the following publication:
 }
 ```
 
-* **Chipyard**
-    * A. Amid, et al. *IEEE Micro'20* [PDF](https://ieeexplore.ieee.org/document/9099108).
-    * A. Amid, et al. *DAC'20* [PDF](https://ieeexplore.ieee.org/document/9218756).
-    * A. Amid, et al. *ISCAS'21* [PDF](https://ieeexplore.ieee.org/abstract/document/9401515).
 
-These additional publications cover many of the internal components used in Chipyard. However, for the most up-to-date details, users should refer to the Chipyard docs.
+```
+@inproceedings{10.1145/3489517.3530672,
+author = {Liew, Harrison and Grubb, Daniel and Wright, John and Schmidt, Colin and Krzysztofowicz, Nayiri and Izraelevitz, Adam and Wang, Edward and Asanovi\'{c}, Krste and Bachrach, Jonathan and Nikoli\'{c}, Borivoje},
+title = {Hammer: a modular and reusable physical design flow tool: invited},
+year = {2022},
+isbn = {9781450391429},
+publisher = {Association for Computing Machinery},
+address = {New York, NY, USA},
+url = {https://doi.org/10.1145/3489517.3530672},
+doi = {10.1145/3489517.3530672},
+abstract = {Process technology scaling and hardware architecture specialization have vastly increased the need for chip design space exploration, while optimizing for power, performance, and area. Hammer is an open-source, reusable physical design (PD) flow generator that reduces design effort and increases portability by enforcing a separation among design-, tool-, and process technology-specific concerns with a modular software architecture. In this work, we outline Hammer's structure and highlight recent extensions that support both physical chip designers and hardware architects evaluating the merit and feasibility of their proposed designs. This is accomplished through the integration of more tools and process technologies---some open-source---and the designer-driven development of flow step generators. An evaluation of chip designs in process technologies ranging from 130nm down to 12nm across a series of RISC-V-based chips shows how Hammer-generated flows are reusable and enable efficient optimization for diverse applications.},
+booktitle = {Proceedings of the 59th ACM/IEEE Design Automation Conference},
+pages = {1335–1338},
+numpages = {4},
+location = {San Francisco, California},
+series = {DAC '22}
+}
+```
 
-* **Generators**
-    * **Rocket Chip**: K. Asanovic, et al., *UCB EECS TR*. [PDF](http://www2.eecs.berkeley.edu/Pubs/TechRpts/2016/EECS-2016-17.pdf).
-    * **BOOM**: C. Celio, et al., *Hot Chips 30*. [PDF](https://old.hotchips.org/hc30/1conf/1.03_Berkeley_BROOM_HC30.Berkeley.Celio.v02.pdf).
-      * **SonicBOOM (BOOMv3)**: J. Zhao, et al., *CARRV'20*. [PDF](https://carrv.github.io/2020/papers/CARRV2020_paper_15_Zhao.pdf).
-      * **COBRA (BOOM Branch Prediction)**: J. Zhao, et al., *ISPASS'21*. [PDF](https://ieeexplore.ieee.org/document/9408173).
-    * **Gemmini**: H. Genc, et al., *DAC'21*. [PDF](https://arxiv.org/pdf/1911.09925).
-* **Sims**
-    * **FireSim**: S. Karandikar, et al., *ISCA'18*. [PDF](https://sagark.org/assets/pubs/firesim-isca2018.pdf).
-        * **FireSim Micro Top Picks**: S. Karandikar, et al., *IEEE Micro, Top Picks 2018*. [PDF](https://sagark.org/assets/pubs/firesim-micro-top-picks2018.pdf).
-        * **FASED**: D. Biancolin, et al., *FPGA'19*. [PDF](https://people.eecs.berkeley.edu/~biancolin/papers/fased-fpga19.pdf).
-        * **Golden Gate**: A. Magyar, et al., *ICCAD'19*. [PDF](https://davidbiancolin.github.io/papers/goldengate-iccad19.pdf).
-        * **FirePerf**: S. Karandikar, et al., *ASPLOS'20*. [PDF](https://sagark.org/assets/pubs/fireperf-asplos2020.pdf).
-        * **FireSim ISCA@50 Retrospective**: S. Karandikar, et al., *ISCA@50 Retrospective: 1996-2020*. [PDF](https://sites.coecis.cornell.edu/isca50retrospective/files/2023/06/Karandikar_2018_FireSim.pdf)
-* **Tools**
-    * **Chisel**: J. Bachrach, et al., *DAC'12*. [PDF](https://people.eecs.berkeley.edu/~krste/papers/chisel-dac2012.pdf).
-    * **FIRRTL**: A. Izraelevitz, et al., *ICCAD'17*. [PDF](https://ieeexplore.ieee.org/document/8203780).
-    * **Chisel DSP**: A. Wang, et al., *DAC'18*. [PDF](https://ieeexplore.ieee.org/document/8465790).
-    * **FireMarshal**: N. Pemberton, et al., *ISPASS'21*. [PDF](https://ieeexplore.ieee.org/document/9408192).
-* **VLSI**
-    * **Hammer**: E. Wang, et al., *ISQED'20*. [PDF](https://www.isqed.org/English/Archives/2020/Technical_Sessions/113.html).
-    * **Hammer**: H. Liew, et al., *DAC'22*. [PDF](https://dl.acm.org/doi/abs/10.1145/3489517.3530672).
-
-## Acknowledgements
-
-This work is supported by the NSF CCRI ENS Chipyard Award #2016662.
-
-[hammer]:https://github.com/ucb-bar/hammer
-[firesim]:https://fires.im
-[ucb-bar]: http://bar.eecs.berkeley.edu
-[eecs]: https://eecs.berkeley.edu
-[berkeley]: https://berkeley.edu
-[riscv]: https://riscv.org/
-[rocket-chip]: https://github.com/freechipsproject/rocket-chip
-[boom]: https://github.com/riscv-boom/riscv-boom
-[firemarshal]: https://github.com/firesim/FireMarshal/
-[cva6]: https://github.com/openhwgroup/cva6/
-[gemmini]: https://github.com/ucb-bar/gemmini
-[nvdla]: http://nvdla.org/
-[saturn]: https://github.com/ucb-bar/saturn-vectors
-[ara]: https://github.com/pulp-platform/ara
+# Contacts 
+Feel free to contribute with issues, PRs.
+You can contact us at:
+- Francesco Angione (francesco.angione@polito.it)
+- Nicola di Gruttola giardino (nicola,.digruttola@polito.it)
+- Gabriele Filipponi (gabriele.filipponi@polito.it)
+- Giusy Iaria (giusy.iaria@polito.it)

--- a/README_cad.md
+++ b/README_cad.md
@@ -213,7 +213,7 @@ The currently available fault models are (for atpg and fsim):
 - **Stuck-at fault (SAF)**: specify ``FAULT_MODEL=saf``
 - **Transition delay fault (TDF)**: specify ``FAULT_MODEL=tdf``
 - **Small Delay faults (SDF)**: specify ``FAULT_MODEL=sdf``
-- **Transient faults (TRN))**: specify ``FAULT_MODEL=trn`` (only for functional fault simulation)
+- **Transient faults (TRN))**: specify ``FAULT_MODEL=tn`` (only for functional fault simulation)
 
 ## Auto-update the program counter from which the VC-Z01X injection shall start
 

--- a/README_cad.md
+++ b/README_cad.md
@@ -206,6 +206,15 @@ export SIM_USE_GUI=true
 
 For fault simulation, vc-zoix is used. Under vlsi/fsim-utilities the sff files, strobe and tcl for fault simulation are present. Modify only the SystemVerilog strobe file and the sff files. Modify the ```FAULT_MODEL_FSIM``` in the fsim.mk file to choose between the 3 available fault models.
 
+
+## Fault models
+
+The currently available fault models are (for atpg and fsim):
+- **Stuck-at fault (SAF)**: specify ``FAULT_MODEL=saf``
+- **Transition delay fault (TDF)**: specify ``FAULT_MODEL=tdf``
+- **Small Delay faults (SDF)**: specify ``FAULT_MODEL=sdf``
+- **Transient faults (TRN))**: specify ``FAULT_MODEL=trn`` (only for functional fault simulation)
+
 ## Auto-update the program counter from which the VC-Z01X injection shall start
 
 The script `vlsi/fsim/strobe/find_main.py` can automatically set the address used by `START_INJECTION` in `vlsi/fsim/strobe/strobe_rocket.sv`.
@@ -269,6 +278,52 @@ $ cd vlsi
 $ export TEST_PATH=absolute_path/tests/hello.riscv
 $ make fsim-syn tutorial=nangate45-commercial-rocket BINARY=${TEST_PATH} LOADMEM=${TEST_PATH} STANDARD_FAULT_FORMAT=/path/to/atpg_fault_list CLOCK_PERIOD=SYNTHESIS_CLOCK FSIM_CONF_FILE=vlsi_dir/fsim/example-fsim-rocket-sdf.yml FSIM_CAMPAIGN_TCL=vlsi_dir/fsim/script/fsim_sdf.tcl FAULT_MODEL=sdf
 ```
+## The FSIM folder in VLSI 
+
+This repository packages fault-simulation collateral (fault lists, Tcl runtime scripts, and strobe logic) that can be consumed from a Hammer:
+- `fault_list/`
+  - Pre-generated fault-definition files (`*.sff`) used by Zoix/VC FSim campaigns.
+  - Includes examples for different fault models:
+    - `gen_saf_*.sff`: stuck-at faults
+    - `gen_tdf_*.sff`: transition-delay faults
+    - `gen_tf_*.sff`: timing-window style generation
+
+- `script/`
+  - Tcl scripts that execute or assist fault simulation campaigns.
+  - `fsim.tcl`: primary campaign runtime (concurrent run, fallback serial run, summary and hierarchical reports).
+  - `fsim_vcstatic.tcl`: alternate script with static/formal-style setup and report generation.
+  - `vc_rtl.tcl`: RTL VCF setup (clock/reset initialization).
+  - `vc_netlist.tcl`: netlist VCF setup, including DFT/test pin constraints.
+
+- `strobe/`
+  - SystemVerilog strobe modules with `$fs_inject` and `$fs_strobe` hooks.
+  - `strobe_rocket.sv`: Rocket-specific strobe and optional label-gated injection.
+  - `strobe_boom.sv`, `strobe_boomv4.sv`: BOOM-specific strobe variants.
+  - `find_injection_label.py`: utility to extract a symbol address from an ELF and patch `START_INJECTION_LABEL` in `strobe_rocket.sv`.
+
+- `example-fsim-*.yml`
+  - Example high-level input configs (`fsim.inputs`) for SAF/TDF/SDF style setups.
+  - These describe fault locations, coverage formulae, optional elaboration flags, strobe modules, and constraints.
+
+You can use the provided `example-fsim-*.yml` files as templates to create your own input configurations for different fault models and DUTs. The YAML format allows you to specify various parameters such as the fault list file, strobe module, coverage formula, and any additional constraints or filters for fault locations. Make sure to adjust the paths and parameters according to your specific design and verification needs.
+
+You can use your custom strobe files, fault lists by passing the appropriate variables to the make command, e.g.:
+
+```bash
+$ make fsim \
+    FSIM_INPUTS=example-fsim-saf.yml \
+    FSIM_STROBE=strobe_rocket.sv \
+    FSIM_FAULT_LIST=fault_list/gen_saf_rocket.sff
+```
+
+## Notes and Caveats
+
+- Hierarchical paths in YAML/SFF/strobe files are design-specific (`ChipTop...`). Update if your elaborated hierarchy differs.
+- `strobe_rocket.sv` depends on `wb_reg_pc` path and the `START_INJECTION_LABEL` macro; verify signal naming in your build.
+- `vc_netlist.tcl` includes OR1200-specific constants and constraints; use as a template if your DUT is not OR1200.
+- Keep fault location filters (`exclude: True/False`) aligned between your YAML and generated SFF to avoid mismatches.
+
+
 
 # ATPG (Automatic Test Pattern Generation)
 

--- a/README_chipyard.md
+++ b/README_chipyard.md
@@ -1,0 +1,102 @@
+
+![CHIPYARD](https://github.com/ucb-bar/chipyard/raw/main/docs/_static/images/chipyard-logo-full.png)
+# Chipyard Framework [![Test](https://github.com/ucb-bar/chipyard/actions/workflows/chipyard-run-tests.yml/badge.svg)](https://github.com/ucb-bar/chipyard/actions)
+
+## Quick Links
+
+* **Latest Documentation**: https://chipyard.readthedocs.io/
+* **User Question Forum**: https://groups.google.com/forum/#!forum/chipyard
+* **Bugs and Feature Requests**: https://github.com/ucb-bar/chipyard/issues
+
+## Using Chipyard
+
+To get started using Chipyard, see the documentation on the Chipyard documentation site: https://chipyard.readthedocs.io/
+
+## What is Chipyard
+
+Chipyard is an open source framework for agile development of Chisel-based systems-on-chip.
+It will allow you to leverage the Chisel HDL, Rocket Chip SoC generator, and other [Berkeley][berkeley] projects to produce a [RISC-V][riscv] SoC with everything from MMIO-mapped peripherals to custom accelerators.
+Chipyard contains processor cores ([Rocket][rocket-chip], [BOOM][boom], [CVA6 (Ariane)][cva6]), vector units ([Saturn][saturn], [Ara][ara]), accelerators ([Gemmini][gemmini], [NVDLA][nvdla]), memory systems, and additional peripherals and tooling to help create a full featured SoC.
+Chipyard supports multiple concurrent flows of agile hardware development, including software RTL simulation, FPGA-accelerated simulation ([FireSim][firesim]), automated VLSI flows ([Hammer][hammer]), and software workload generation for bare-metal and Linux-based systems ([FireMarshal][firemarshal]).
+Chipyard is actively developed in the [Berkeley Architecture Research Group][ucb-bar] in the [Electrical Engineering and Computer Sciences Department][eecs] at the [University of California, Berkeley][berkeley].
+
+## Resources
+
+* Chipyard Documentation: https://chipyard.readthedocs.io/
+* Chipyard (x FireSim) Tutorial: https://fires.im/tutorial-recent/
+* Chipyard Basics slides: https://fires.im/asplos23-slides-pdf/02_chipyard_basics.pdf
+
+## Need help?
+
+* Join the Chipyard Mailing List: https://groups.google.com/forum/#!forum/chipyard
+* If you find a bug or would like propose a feature, post an issue on this repo: https://github.com/ucb-bar/chipyard/issues
+
+## Contributing
+
+* See [CONTRIBUTING.md](/CONTRIBUTING.md)
+
+## Attribution and Chipyard-related Publications
+
+If used for research, please cite Chipyard by the following publication:
+
+```
+@article{chipyard,
+  author={Amid, Alon and Biancolin, David and Gonzalez, Abraham and Grubb, Daniel and Karandikar, Sagar and Liew, Harrison and Magyar,   Albert and Mao, Howard and Ou, Albert and Pemberton, Nathan and Rigge, Paul and Schmidt, Colin and Wright, John and Zhao, Jerry and Shao, Yakun Sophia and Asanovi\'{c}, Krste and Nikoli\'{c}, Borivoje},
+  journal={IEEE Micro},
+  title={Chipyard: Integrated Design, Simulation, and Implementation Framework for Custom SoCs},
+  year={2020},
+  volume={40},
+  number={4},
+  pages={10-21},
+  doi={10.1109/MM.2020.2996616},
+  ISSN={1937-4143},
+}
+```
+
+* **Chipyard**
+    * A. Amid, et al. *IEEE Micro'20* [PDF](https://ieeexplore.ieee.org/document/9099108).
+    * A. Amid, et al. *DAC'20* [PDF](https://ieeexplore.ieee.org/document/9218756).
+    * A. Amid, et al. *ISCAS'21* [PDF](https://ieeexplore.ieee.org/abstract/document/9401515).
+
+These additional publications cover many of the internal components used in Chipyard. However, for the most up-to-date details, users should refer to the Chipyard docs.
+
+* **Generators**
+    * **Rocket Chip**: K. Asanovic, et al., *UCB EECS TR*. [PDF](http://www2.eecs.berkeley.edu/Pubs/TechRpts/2016/EECS-2016-17.pdf).
+    * **BOOM**: C. Celio, et al., *Hot Chips 30*. [PDF](https://old.hotchips.org/hc30/1conf/1.03_Berkeley_BROOM_HC30.Berkeley.Celio.v02.pdf).
+      * **SonicBOOM (BOOMv3)**: J. Zhao, et al., *CARRV'20*. [PDF](https://carrv.github.io/2020/papers/CARRV2020_paper_15_Zhao.pdf).
+      * **COBRA (BOOM Branch Prediction)**: J. Zhao, et al., *ISPASS'21*. [PDF](https://ieeexplore.ieee.org/document/9408173).
+    * **Gemmini**: H. Genc, et al., *DAC'21*. [PDF](https://arxiv.org/pdf/1911.09925).
+* **Sims**
+    * **FireSim**: S. Karandikar, et al., *ISCA'18*. [PDF](https://sagark.org/assets/pubs/firesim-isca2018.pdf).
+        * **FireSim Micro Top Picks**: S. Karandikar, et al., *IEEE Micro, Top Picks 2018*. [PDF](https://sagark.org/assets/pubs/firesim-micro-top-picks2018.pdf).
+        * **FASED**: D. Biancolin, et al., *FPGA'19*. [PDF](https://people.eecs.berkeley.edu/~biancolin/papers/fased-fpga19.pdf).
+        * **Golden Gate**: A. Magyar, et al., *ICCAD'19*. [PDF](https://davidbiancolin.github.io/papers/goldengate-iccad19.pdf).
+        * **FirePerf**: S. Karandikar, et al., *ASPLOS'20*. [PDF](https://sagark.org/assets/pubs/fireperf-asplos2020.pdf).
+        * **FireSim ISCA@50 Retrospective**: S. Karandikar, et al., *ISCA@50 Retrospective: 1996-2020*. [PDF](https://sites.coecis.cornell.edu/isca50retrospective/files/2023/06/Karandikar_2018_FireSim.pdf)
+* **Tools**
+    * **Chisel**: J. Bachrach, et al., *DAC'12*. [PDF](https://people.eecs.berkeley.edu/~krste/papers/chisel-dac2012.pdf).
+    * **FIRRTL**: A. Izraelevitz, et al., *ICCAD'17*. [PDF](https://ieeexplore.ieee.org/document/8203780).
+    * **Chisel DSP**: A. Wang, et al., *DAC'18*. [PDF](https://ieeexplore.ieee.org/document/8465790).
+    * **FireMarshal**: N. Pemberton, et al., *ISPASS'21*. [PDF](https://ieeexplore.ieee.org/document/9408192).
+* **VLSI**
+    * **Hammer**: E. Wang, et al., *ISQED'20*. [PDF](https://www.isqed.org/English/Archives/2020/Technical_Sessions/113.html).
+    * **Hammer**: H. Liew, et al., *DAC'22*. [PDF](https://dl.acm.org/doi/abs/10.1145/3489517.3530672).
+
+## Acknowledgements
+
+This work is supported by the NSF CCRI ENS Chipyard Award #2016662.
+
+[hammer]:https://github.com/ucb-bar/hammer
+[firesim]:https://fires.im
+[ucb-bar]: http://bar.eecs.berkeley.edu
+[eecs]: https://eecs.berkeley.edu
+[berkeley]: https://berkeley.edu
+[riscv]: https://riscv.org/
+[rocket-chip]: https://github.com/freechipsproject/rocket-chip
+[boom]: https://github.com/riscv-boom/riscv-boom
+[firemarshal]: https://github.com/firesim/FireMarshal/
+[cva6]: https://github.com/openhwgroup/cva6/
+[gemmini]: https://github.com/ucb-bar/gemmini
+[nvdla]: http://nvdla.org/
+[saturn]: https://github.com/ucb-bar/saturn-vectors
+[ara]: https://github.com/pulp-platform/ara

--- a/eda_tools_setup
+++ b/eda_tools_setup
@@ -1,7 +1,7 @@
 #!/bin/bash
 module load license/default
 module load synopsys/vcs/2024.09-SP1
-module load synopsys/syn/2022.12
+module load synopsys/syn/2024.09-SP2
 module load synopsys/tmax/2022.12
 module load cadence/innovus/19.11_000
 module load synopsys/verdi/2024.09-SP1

--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -12,6 +12,7 @@ sim_dir=$(abspath .)
 #########################################################################################
 # include shared variables
 #########################################################################################
+include $(vlsi_dir)/benchmarks.mk
 include $(vlsi_dir)/tutorial.mk
 include $(base_dir)/variables.mk
 

--- a/vlsi/benchmarks.mk
+++ b/vlsi/benchmarks.mk
@@ -1,0 +1,61 @@
+#########################################################################################
+# makefile variables for VLSI benchmarks
+#########################################################################################
+benchmark ?= none
+tech_name ?= nangate45
+toolchain ?= commercial
+
+EXTRA_CONFS ?=
+
+
+ifeq ($(benchmark),ibex)
+    CONFIG            = IbexConfig
+    generated_src_name ?= generated-src-$(tech_name)
+    HAMMER_EXEC       = ./example-vlsi
+    TOOLS_CONF        ?= example-tools.yml
+    TECH_CONF         ?= ./technology/$(tech_name).yml
+    FSIM_CONF_FILE    ?= ./fsim/example-fsim.yml
+    DESIGN_CONFS      ?= ./example-designs/$(tech_name)-$(toolchain).yml
+    VLSI_OBJ_DIR      ?= build-$(tech_name)-$(toolchain)-$(benchmark)
+    INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
+endif
+
+
+
+ifeq ($(benchmark),rocket)
+    CONFIG            = RocketConfig
+    generated_src_name ?= generated-src-$(tech_name)
+    HAMMER_EXEC       = ./example-vlsi
+    TOOLS_CONF        ?= example-tools.yml
+    TECH_CONF         ?= ./technology/$(tech_name).yml
+    FSIM_CONF_FILE    ?= ./fsim/example-fsim.yml
+    DESIGN_CONFS      ?= ./example-designs/$(tech_name)-$(toolchain).yml
+    VLSI_OBJ_DIR      ?= build-$(tech_name)-$(toolchain)-$(benchmark)
+    INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
+endif
+
+
+ifeq ($(benchmark),boom-small)
+    CONFIG            = IbexConfig
+    generated_src_name ?= generated-src-$(tech_name)
+    HAMMER_EXEC       = ./example-vlsi
+    TOOLS_CONF        ?= example-tools.yml
+    TECH_CONF         ?= ./technology/$(tech_name).yml
+    FSIM_CONF_FILE    ?= ./fsim/example-fsim.yml
+    DESIGN_CONFS      ?= ./example-designs/$(tech_name)-$(toolchain).yml
+    VLSI_OBJ_DIR      ?= build-$(tech_name)-$(toolchain)-$(benchmark)
+    INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
+endif
+
+
+ifeq ($(benchmark),cva6)
+    CONFIG            = CVA6Config
+    generated_src_name ?= generated-src-$(tech_name)
+    HAMMER_EXEC       =  ./vlsi-cva6
+    TOOLS_CONF        ?= example-tools.yml
+    TECH_CONF         ?= ./technology/$(tech_name).yml
+    FSIM_CONF_FILE    ?= ./fsim/example-fsim.yml
+    DESIGN_CONFS      ?= ./example-designs/$(tech_name)-$(toolchain).yml
+    VLSI_OBJ_DIR      ?= build-$(tech_name)-$(toolchain)-$(benchmark)
+    INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
+endif

--- a/vlsi/benchmarks.mk
+++ b/vlsi/benchmarks.mk
@@ -36,7 +36,7 @@ endif
 
 
 ifeq ($(benchmark),boom-small)
-    CONFIG            = IbexConfig
+    CONFIG            = SmallBoomV3Config
     generated_src_name ?= generated-src-$(tech_name)
     HAMMER_EXEC       = ./example-vlsi
     TOOLS_CONF        ?= example-tools.yml

--- a/vlsi/example-tools.yml
+++ b/vlsi/example-tools.yml
@@ -2,7 +2,7 @@
 vlsi.core.build_system: make
 # Design Compiler options
 vlsi.core.synthesis_tool: "hammer.synthesis.dc"
-synthesis.dc.version: "SYN_2022.12"
+synthesis.dc.version: "SYN_2024.09-SP2"
 synthesis.spyglass.version: "2023.12-SP1"
 synthesis.library_compiler.version: "LC_2024.09-SP2"
 vlsi.core.synthesis_tool.compile_args : ["-scan", "-incremental", " -no_autoungroup" , "-no_boundary_optimization"]

--- a/vlsi/technology/nangate45.yml
+++ b/vlsi/technology/nangate45.yml
@@ -5,4 +5,4 @@ vlsi.core.technology: "hammer.technology.nangate45"
 technology.nangate45.install_dir: "/data/libraries/NangateOpenCellLibrary_PDKv1_3_v2010_12/"
 
 # For generating fake srams
-vlsi.core.sram_generator_tool: "hammer.sram_generator.generic_generator"
+vlsi.core.sram_generator_tool: "hammer.technology.nangate45.sram_compiler"


### PR DESCRIPTION
This pull request introduces significant improvements and clarifications to the documentation for VLSI hardware testing benchmarks, along with minor updates to EDA tool setup and Makefile includes. The most notable changes are a complete rewrite and expansion of the main `README.md` to better explain the framework’s purpose, usage, and citation, the addition of detailed documentation for the FSIM collateral and fault models, and updates to EDA tool versions.

**Documentation Overhaul and Expansion**

* Major rewrite of `README.md` to provide a clear overview of the VLSI benchmarking framework, its integration with Chipyard and Hammer, supported fault models, usage instructions, and citation guidance. The new README emphasizes the framework’s research-focused goals and modernizes the presentation.
* Addition of a detailed section in `README_cad.md` describing available fault models (SAF, TDF, SDF, TRN) and their usage, as well as comprehensive documentation of the FSIM folder structure, example YAML configuration, and important notes for customizing fault simulation flows. [[1]](diffhunk://#diff-52205bc3a00e5db67aa4b99ca47b404f25a45d546c0bfd824bfc4a7d6b858bd0R209-R217) [[2]](diffhunk://#diff-52205bc3a00e5db67aa4b99ca47b404f25a45d546c0bfd824bfc4a7d6b858bd0R281-R326)

**Reference and Citation Updates**

* Updated and streamlined the citation section in `README.md`, including a new BibTeX entry for Hammer and improved contact information for maintainers.

**Tooling and Infrastructure**

* Updated the EDA tool setup script to use a newer version of Synopsys Design Compiler (`syn/2024.09-SP2`), ensuring compatibility with the latest toolchains.
* Modified the `vlsi/Makefile` to include `benchmarks.mk` for shared variable management, improving build configuration.

**Repository Structure**

* Added a new `README_chipyard.md` that restores the original Chipyard documentation and publication references, allowing users to access upstream documentation easily.<!--
