### PR TITLE
Hotfix: flow and asap7 configuration

### DIFF
--- a/vlsi/benchmarks.mk
+++ b/vlsi/benchmarks.mk
@@ -2,7 +2,7 @@
 # makefile variables for VLSI benchmarks
 #########################################################################################
 benchmark ?= none
-tech_name ?= nangate45
+technology_name ?= nangate45
 toolchain ?= commercial
 
 EXTRA_CONFS ?=
@@ -10,13 +10,13 @@ EXTRA_CONFS ?=
 
 ifeq ($(benchmark),ibex)
     CONFIG            = IbexConfig
-    generated_src_name ?= generated-src-$(tech_name)
+    generated_src_name ?= generated-src-$(technology_name)
     HAMMER_EXEC       = ./example-vlsi
     TOOLS_CONF        ?= example-tools.yml
-    TECH_CONF         ?= ./technology/$(tech_name).yml
+    TECH_CONF         ?= ./technology/$(technology_name).yml
     FSIM_CONF_FILE    ?= ./fsim/example-fsim.yml
-    DESIGN_CONFS      ?= ./example-designs/$(tech_name)-$(toolchain).yml
-    VLSI_OBJ_DIR      ?= build-$(tech_name)-$(toolchain)-$(benchmark)
+    DESIGN_CONFS      ?= ./example-designs/$(technology_name)-$(toolchain).yml
+    VLSI_OBJ_DIR      ?= build-$(technology_name)-$(toolchain)-$(benchmark)
     INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
 endif
 
@@ -24,38 +24,53 @@ endif
 
 ifeq ($(benchmark),rocket)
     CONFIG            = RocketConfig
-    generated_src_name ?= generated-src-$(tech_name)
+    generated_src_name ?= generated-src-$(technology_name)
     HAMMER_EXEC       = ./example-vlsi
     TOOLS_CONF        ?= example-tools.yml
-    TECH_CONF         ?= ./technology/$(tech_name).yml
+    TECH_CONF         ?= ./technology/$(technology_name).yml
     FSIM_CONF_FILE    ?= ./fsim/example-fsim.yml
-    DESIGN_CONFS      ?= ./example-designs/$(tech_name)-$(toolchain).yml
-    VLSI_OBJ_DIR      ?= build-$(tech_name)-$(toolchain)-$(benchmark)
+    DESIGN_CONFS      ?= ./example-designs/$(technology_name)-$(toolchain).yml
+    VLSI_OBJ_DIR      ?= build-$(technology_name)-$(toolchain)-$(benchmark)
     INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
 endif
 
 
 ifeq ($(benchmark),boom-small)
     CONFIG            = SmallBoomV3Config
-    generated_src_name ?= generated-src-$(tech_name)
+    generated_src_name ?= generated-src-$(technology_name)
     HAMMER_EXEC       = ./example-vlsi
     TOOLS_CONF        ?= example-tools.yml
-    TECH_CONF         ?= ./technology/$(tech_name).yml
+    TECH_CONF         ?= ./technology/$(technology_name).yml
     FSIM_CONF_FILE    ?= ./fsim/example-fsim.yml
-    DESIGN_CONFS      ?= ./example-designs/$(tech_name)-$(toolchain).yml
-    VLSI_OBJ_DIR      ?= build-$(tech_name)-$(toolchain)-$(benchmark)
+    DESIGN_CONFS      ?= ./example-designs/$(technology_name)-$(toolchain).yml
+    VLSI_OBJ_DIR      ?= build-$(technology_name)-$(toolchain)-$(benchmark)
     INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
 endif
 
 
 ifeq ($(benchmark),cva6)
     CONFIG            = CVA6Config
-    generated_src_name ?= generated-src-$(tech_name)
+    generated_src_name ?= generated-src-$(technology_name)
     HAMMER_EXEC       =  ./vlsi-cva6
     TOOLS_CONF        ?= example-tools.yml
-    TECH_CONF         ?= ./technology/$(tech_name).yml
+    TECH_CONF         ?= ./technology/$(technology_name).yml
     FSIM_CONF_FILE    ?= ./fsim/example-fsim.yml
-    DESIGN_CONFS      ?= ./example-designs/$(tech_name)-$(toolchain).yml
-    VLSI_OBJ_DIR      ?= build-$(tech_name)-$(toolchain)-$(benchmark)
+    DESIGN_CONFS      ?= ./example-designs/$(technology_name)-$(toolchain).yml
+    VLSI_OBJ_DIR      ?= build-$(technology_name)-$(toolchain)-$(benchmark)
     INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
 endif
+
+
+ifeq ($(benchmark),radiance)
+    CONFIG            = RadianceTapeoutSimConfig 
+    generated_src_name ?= generated-src-$(technology_name)
+    HAMMER_EXEC       =  ./example-vlsi
+    TOOLS_CONF        ?= example-tools.yml
+    TECH_CONF         ?= ./technology/$(technology_name).yml
+    FSIM_CONF_FILE    ?= ./fsim/example-fsim.yml
+    DESIGN_CONFS      ?= ./example-designs/$(technology_name)-$(toolchain).yml
+    VLSI_OBJ_DIR      ?= build-$(technology_name)-$(toolchain)-$(benchmark)
+    INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
+endif
+
+

--- a/vlsi/benchmarks.mk
+++ b/vlsi/benchmarks.mk
@@ -11,7 +11,7 @@ EXTRA_CONFS ?=
 ifeq ($(benchmark),ibex)
     CONFIG            = IbexConfig
     generated_src_name ?= generated-src-$(technology_name)
-    HAMMER_EXEC       = ./example-vlsi
+    HAMMER_EXEC       = ./vlsi-ibex
     TOOLS_CONF        ?= example-tools.yml
     TECH_CONF         ?= ./technology/$(technology_name).yml
     FSIM_CONF_FILE    ?= ./fsim/example-fsim.yml

--- a/vlsi/env.yml
+++ b/vlsi/env.yml
@@ -10,5 +10,3 @@ cadence.CDS_LIC_FILE: ""
 synopsys.synopsys_home: "/eda/synopsys/2024-25/RHELx86/"
 # Synopsys license server/files
 synopsys.SNPSLMD_LICENSE_FILE: ""
-
-#vlsi.core.sram_generator_tool: "hammer.technology.nangate45.sram_compiler"

--- a/vlsi/example-designs/asap7-commercial.yml
+++ b/vlsi/example-designs/asap7-commercial.yml
@@ -2,17 +2,25 @@ vlsi.core.max_threads: 12
 
 # General Hammer Inputs
 
-# Hammer will auto-generate a CPF for simple power designs; see hammer/src/hammer-vlsi/defaults.yml for more info
-vlsi.inputs.power_spec_mode: "auto"
-vlsi.inputs.power_spec_type: "cpf"
 
 # Specify clock signals
 vlsi.inputs.clocks: [
-  {name: "clock_uncore", period: "1ns", uncertainty: "0.1ns"}
+  {name: "clock_uncore", period: "1ns", uncertainty: "0.01ns"}
 ]
 
+vlsi.inputs.resets: [
+  {name: "reset_io", active_negated: "false", "synchronous" : "false"}
+]
 # Generate Make include to aid in flow
 vlsi.core.build_system: make
+
+# Custom compile options 
+
+vlsi.core.synthesis_tool.compile_args : ["-scan", "-incremental", "-no_autoungroup" , "-gate_clock", "-no_boundary_optimization"]
+
+# Adding clock gating capabilties during the synthesis
+synthesis.clock_gating_mode : "auto"
+
 
 # Placement Constraints
 # For ASAP7, all numbers must be 4x larger than final GDS
@@ -89,8 +97,7 @@ synthesis.dc.dft.scan.ports : [
 ]
 synthesis.dc.dft.scan.clock_ports: [
   {"name" : "jtag_TCK", "active_state" : "1", "timings" : ["45" , "95"] },
-  {"name" : "clock_uncore", "active_state" : "1", "timings" : ["45" , "95"] },
-  {"name" : "serial_tl_0_clock_in", "active_state" : "1", "timings" : ["45" , "95"] }
+  {"name" : "clock_uncore", "active_state" : "1", "timings" : ["45" , "95"] }
 ]
 
 synthesis.dc.dft.reset_ports : [

--- a/vlsi/example-vlsi
+++ b/vlsi/example-vlsi
@@ -35,6 +35,20 @@ set_db route_design_top_routing_layer 7
 ''')
     return True
 
+def add_options(x: HammerTool) -> bool:
+    if x.get_setting("vlsi.core.technology") == "hammer.technology.asap7":
+        # Needed by design compiler because asap7 has no three state cells
+        if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
+            x.append("set_app_var compile_assume_fully_decoded_three_state_busses true")
+    return True 
+
+def connect_clk_en_reg(x: HammerTool) -> bool:
+    if x.get_setting("vlsi.core.technology") == "hammer.technology.asap7":
+        if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
+            x.append("disconnect_net [all_connected clock_en_reg/RESET] clock_en_reg/RESET")
+            x.append("connect_pin -from [get_nets n_debug_reset_syncd_debug_reset_sync_io_q ] -to clock_en_reg/RESET ")
+    return True
+
 class ExampleDriver(CLIDriver):
     def get_extra_par_hooks(self) -> List[HammerToolHookAction]:
         extra_hooks = [
@@ -54,6 +68,14 @@ class ExampleDriver(CLIDriver):
             HammerTool.make_removal_hook("place_bumps"),
 
             # The target step in any of the above calls may be a default step or another one of your custom hooks
+        ]
+        return extra_hooks
+
+    def get_extra_synthesis_hooks(self) -> List[HammerToolHookAction]:
+        extra_hooks = [
+            HammerTool.make_post_insertion_hook("init_environment", add_options),
+            HammerTool.make_pre_insertion_hook("configure_dft", connect_clk_en_reg),
+
         ]
         return extra_hooks
 

--- a/vlsi/fsim/example-fsim.yml
+++ b/vlsi/fsim/example-fsim.yml
@@ -1,0 +1,34 @@
+fsim.inputs:
+
+  # Optional execution flags for the fault simulator
+  optional_elaboration_flags: ["+vcs+fsdbon"]
+
+
+  # Determine the weights of all the parameters in the test and fault coverage
+  weights: [
+    {fault_class: "PT", weight: "1.0"}
+  ]
+
+  test_coverage: "(DD * DD_weight + DT * DT_weight + DE * DE_weight + DF * DF_weight + PD * PD_weight + PT * PT_weight)/(Total)"
+  fault_coverage: "(DD * DD_weight + DT * DT_weight + DE * DE_weight + DF * DF_weight + PD * PD_weight + PT * PT_weight)/(Total + UB + UI + UR + UT + UU + UO)"
+
+
+  # Determines the fault locations and types
+  fault_locations: [
+    {location: "ChipTop.**", 
+              fault_type: "0,1", type_of_fault_location: "PORT", exclude: False},
+    
+  ]
+
+  # Strobe position if strobe file is not provided
+  strobe_modules: [
+    "TestDriver.testHarness.chiptop0", 
+  ]
+
+  # Contraints for the sff file - Example on how to use
+  # constraints: [
+  #  {name: "one", entries:
+  #        [{type: "U*", signal: "ChipTop.system.tile_prci_domain.element_reset_domain_boom_tile.core.*", value: "1"},
+  #        {type: "U*", signal: "ChipTop.system.tile_prci_domain.element_reset_domain_boom_tile.core.*", value: "0"}]},
+  #  {name: "safe", entries: [{type: "U*", signal: "ChipTop.system.tile_prci_domain.element_reset_domain_boom_tile.core.*", value: "0"}]}
+  # ]

--- a/vlsi/technology/asap7.yml
+++ b/vlsi/technology/asap7.yml
@@ -7,4 +7,13 @@ technology.asap7.pdk_install_dir: "/data/libraries/asap7/asap7_pdk_r1p7/"
 technology.asap7.stdcell_install_dir: "/data/libraries/asap7/asap7sc7p5t_27/"
 
 # For generating fake srams
-vlsi.core.sram_generator_tool: "hammer.sram_generator.generic_generator"
+vlsi.core.sram_generator_tool: "hammer.technology.asap7.sram_compiler"
+
+
+# Used to select the correct liberty files for scan insertion! 
+# CHANGE AT YOUR OWN RISK!
+vlsi:
+  inputs:
+    VDD: "0.7 V"
+    GND: "0.0 V"
+    

--- a/vlsi/vlsi-ibex
+++ b/vlsi/vlsi-ibex
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import os
+
+from hammer.vlsi import CLIDriver, HammerTool, HammerToolHookAction
+
+from typing import Dict, Callable, Optional, List
+
+def example_place_tap_cells(x: HammerTool) -> bool:
+    if x.get_setting("vlsi.core.technology") == "asap7":
+        x.append('''
+# TODO
+# Place custom TCL here
+''')
+    return True
+
+def example_add_fillers(x: HammerTool) -> bool:
+    if x.get_setting("vlsi.core.technology") == "asap7":
+        x.append('''
+# TODO
+# Place custom TCL here
+''')
+    return True
+
+def example_tool_settings(x: HammerTool) -> bool:
+    if x.get_setting("vlsi.core.technology") == "asap7":
+        x.append('''
+# TODO
+# Place custom TCL here
+set_db route_design_bottom_routing_layer 2
+set_db route_design_top_routing_layer 7
+''')
+    return True
+
+def add_options(x: HammerTool) -> bool:
+    if x.get_setting("vlsi.core.technology") == "hammer.technology.asap7":
+        # Needed by design compiler because asap7 has no three state cells
+        if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
+            x.append("set_app_var compile_assume_fully_decoded_three_state_busses true")
+    return True 
+
+
+def connect_black_box_signals(x: HammerTool) -> bool:
+    if x.get_setting("vlsi.core.technology") == "hammer.technology.asap7":
+            if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
+                # Connect top level black box's signals (unconnected) to scan signals
+                x.append("disconnect_net [all_connected system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i] system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i")
+                x.append("connect_pin -from [get_port test_mode]  -to system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i  -port_name test_en_i_core")    
+                x.append("disconnect_net [all_connected system/tile_prci_domain/element_reset_domain_ibex_tile/core/scan_rst_ni] system/tile_prci_domain/element_reset_domain_ibex_tile/core/scan_rst_ni")
+                x.append("connect_pin -from [get_port test_mode] -to system/tile_prci_domain/element_reset_domain_ibex_tile/core/scan_rst_ni  -port_name scan_rst_ni_core")    
+    return True 
+
+
+def connect_clk_en_reg(x: HammerTool) -> bool:
+    if x.get_setting("vlsi.core.technology") == "hammer.technology.asap7":
+        if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
+            x.append("disconnect_net [all_connected clock_en_reg/RESET] clock_en_reg/RESET")
+            x.append("connect_pin -from [get_nets n_debug_reset_syncd_debug_reset_sync_io_q ] -to clock_en_reg/RESET ")
+            x.append("connect_pin -from  [get_ports test_mode] -to [get_nets system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i] ")    
+            x.append("set test_fix_bus true")
+    return True
+    
+class ExampleDriver(CLIDriver):
+    def get_extra_par_hooks(self) -> List[HammerToolHookAction]:
+        extra_hooks = [
+            # Default set of steps can be found in the CAD tool plugin's __init__.py
+
+            # make_pre_insertion_hook will execute the custom hook before the specified step
+            # SYNTAX: make_pre_insertion_hook("EXISTING_STEP", INSERTED_HOOK)
+            # HammerTool.make_pre_insertion_hook("route_design", example_add_fillers),
+
+            # make_post_insertion_hook will execute the custom hook after the specified step
+            # HammerTool.make_post_insertion_hook("init_design", example_tool_settings),
+
+            # make_replacement_hook will replace the specified step with a custom hook
+            # HammerTool.make_replacement_hook("place_tap_cells", example_place_tap_cells),
+
+            # make_removal_hook will remove the specified step from the flow
+            HammerTool.make_removal_hook("place_bumps"),
+
+            # The target step in any of the above calls may be a default step or another one of your custom hooks
+        ]
+        return extra_hooks
+
+    def get_extra_synthesis_hooks(self) -> List[HammerToolHookAction]:
+        extra_hooks = [
+            HammerTool.make_post_insertion_hook("init_environment", add_options),
+            HammerTool.make_pre_insertion_hook("configure_dft", connect_clk_en_reg),
+            HammerTool.make_post_insertion_hook("configure_dft", connect_black_box_signals),
+        ]
+        return extra_hooks
+
+if __name__ == '__main__':
+    ExampleDriver().main()

--- a/vlsi/vlsi-ibex
+++ b/vlsi/vlsi-ibex
@@ -6,32 +6,6 @@ from hammer.vlsi import CLIDriver, HammerTool, HammerToolHookAction
 
 from typing import Dict, Callable, Optional, List
 
-def example_place_tap_cells(x: HammerTool) -> bool:
-    if x.get_setting("vlsi.core.technology") == "asap7":
-        x.append('''
-# TODO
-# Place custom TCL here
-''')
-    return True
-
-def example_add_fillers(x: HammerTool) -> bool:
-    if x.get_setting("vlsi.core.technology") == "asap7":
-        x.append('''
-# TODO
-# Place custom TCL here
-''')
-    return True
-
-def example_tool_settings(x: HammerTool) -> bool:
-    if x.get_setting("vlsi.core.technology") == "asap7":
-        x.append('''
-# TODO
-# Place custom TCL here
-set_db route_design_bottom_routing_layer 2
-set_db route_design_top_routing_layer 7
-''')
-    return True
-
 def add_options(x: HammerTool) -> bool:
     if x.get_setting("vlsi.core.technology") == "hammer.technology.asap7":
         # Needed by design compiler because asap7 has no three state cells
@@ -61,27 +35,6 @@ def connect_clk_en_reg(x: HammerTool) -> bool:
     return True
     
 class ExampleDriver(CLIDriver):
-    def get_extra_par_hooks(self) -> List[HammerToolHookAction]:
-        extra_hooks = [
-            # Default set of steps can be found in the CAD tool plugin's __init__.py
-
-            # make_pre_insertion_hook will execute the custom hook before the specified step
-            # SYNTAX: make_pre_insertion_hook("EXISTING_STEP", INSERTED_HOOK)
-            # HammerTool.make_pre_insertion_hook("route_design", example_add_fillers),
-
-            # make_post_insertion_hook will execute the custom hook after the specified step
-            # HammerTool.make_post_insertion_hook("init_design", example_tool_settings),
-
-            # make_replacement_hook will replace the specified step with a custom hook
-            # HammerTool.make_replacement_hook("place_tap_cells", example_place_tap_cells),
-
-            # make_removal_hook will remove the specified step from the flow
-            HammerTool.make_removal_hook("place_bumps"),
-
-            # The target step in any of the above calls may be a default step or another one of your custom hooks
-        ]
-        return extra_hooks
-
     def get_extra_synthesis_hooks(self) -> List[HammerToolHookAction]:
         extra_hooks = [
             HammerTool.make_post_insertion_hook("init_environment", add_options),


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the VLSI flow, focusing on better support for the ASAP7 technology, enhanced configuration flexibility, and new benchmark and simulation capabilities. The most notable changes include standardizing technology variable names, adding new synthesis hooks and configuration options for ASAP7, introducing a new fault simulation configuration, and adding support for the "radiance" benchmark.

**Improvements for ASAP7 technology and synthesis flow:**

* Standardized the technology variable name from `tech_name` to `technology_name` throughout `benchmarks.mk` and updated all relevant references for consistency.
* Added new synthesis hooks (`add_options`, `connect_clk_en_reg`, and `connect_black_box_signals`) in both `example-vlsi` and the new `vlsi-ibex` driver to handle ASAP7-specific requirements, such as setting three-state bus options and connecting scan/DFT signals. [[1]](diffhunk://#diff-350d337f5bb0b62e5e41d29f659d0a40649039d5242c8882e0c75ed2148a442fR38-R51) [[2]](diffhunk://#diff-350d337f5bb0b62e5e41d29f659d0a40649039d5242c8882e0c75ed2148a442fR74-R81) [[3]](diffhunk://#diff-44fad04143bb69c337434d7dd2e86fdaa2b307d9656e7f9a6f8a4921c4444f5cR1-R47)
* Updated `asap7-commercial.yml` to provide more accurate clock uncertainty, add reset signal definitions, specify advanced synthesis compile arguments, enable clock gating, and refine scan clock port definitions. [[1]](diffhunk://#diff-3e8acc905382de5bd8f6fb6ae42334ea2f7511c6ea91197998f50a2560ea8113L5-R24) [[2]](diffhunk://#diff-3e8acc905382de5bd8f6fb6ae42334ea2f7511c6ea91197998f50a2560ea8113L92-R100)
* Switched the SRAM generator tool for ASAP7 to use `hammer.technology.asap7.sram_compiler` and added VDD/GND settings for proper liberty file selection.

**Benchmark and configuration enhancements:**

* Added support for a new "radiance" benchmark in `benchmarks.mk`, including all necessary configuration variables.
* Added a new fault simulation configuration file (`example-fsim.yml`) with parameters for test/fault coverage, fault locations, and strobe modules.

**Other configuration and cleanup:**

* Cleaned up obsolete SRAM generator tool references in `env.yml`.

These changes collectively improve the flexibility, correctness, and feature set of the VLSI flow, especially for ASAP7-based designs and new benchmarks.