### PR TITLE
feat: moving insert dft and atpg setting to be tool independent

### DIFF
--- a/vlsi/example-designs/asap7-commercial.yml
+++ b/vlsi/example-designs/asap7-commercial.yml
@@ -86,42 +86,48 @@ vlsi.inputs.pin.assignments: [
 ]
 
 # Design Compiler DFT insertion option
-synthesis.dc.dft_insertion : true 
+synthesis.dft_insertion : true 
 # Scan configuration 
-synthesis.dc.insert_dft.scan : true 
-synthesis.dc.dft.scan.style : "multiplexed_flip_flop" 
-synthesis.dc.dft.scan.chain_count : 1
-synthesis.dc.dft.scan.ports : [
+synthesis.insert_dft.scan : true 
+synthesis.dft.scan.style : "multiplexed_flip_flop" 
+synthesis.dft.scan.chain_count : 1
+synthesis.dft.scan.ports : [
   {"name" : "jtag_TDI" , "direction" : "in" , "type": "ScanDataIn"  ,"exist" : true },
   {"name" : "jtag_TDO" , "direction" : "out" , "type": "ScanDataOut"  ,"exist" : true }
 ]
-synthesis.dc.dft.scan.clock_ports: [
+synthesis.dft.scan.clock_ports: [
   {"name" : "jtag_TCK", "active_state" : "1", "timings" : ["45" , "95"] },
   {"name" : "clock_uncore", "active_state" : "1", "timings" : ["45" , "95"] }
 ]
 
-synthesis.dc.dft.reset_ports : [
+synthesis.dft.reset_ports : [
   {"name" : "reset_io", "active_state" : "1"},
   {"name" : "jtag_reset", "active_state" : "1"},
 ]
 # BSD and JTAG
-synthesis.dc.insert_dft.bsd : false # TODO implement boundary scan insertion during the synthesis 
-synthesis.dc.dft.jtag.clk : "jtag_TCK"
-synthesis.dc.dft.jtag.tdi : "jtag_TDI"
-synthesis.dc.dft.jtag.tdo : "jtag_TDO"
-synthesis.dc.dft.jtag.tms : "jtag_TMS"
-synthesis.dc.dft.jtag.reset : "jtag_reset"
+synthesis.insert_dft.bsd : false # TODO implement boundary scan insertion during the synthesis 
+synthesis.dft.jtag.clk : "jtag_TCK"
+synthesis.dft.jtag.tdi : "jtag_TDI"
+synthesis.dft.jtag.tdo : "jtag_TDO"
+synthesis.dft.jtag.tms : "jtag_TMS"
+synthesis.dft.jtag.reset : "jtag_reset"
 # Memory Collar configuration 
-synthesis.dc.insert_dft.memory_wrapper : true 
+synthesis.insert_dft.memory_wrapper : true 
 # Scan compression configuration
-synthesis.dc.insert_dft.scan_compression : false # TODO implement scan compression insertion during the synthesis 
+synthesis.insert_dft.scan_compression : false # TODO implement scan compression insertion during the synthesis 
+
+# Set targeted fault coverage and number of generated test patterns from atpg
+atpg:
+  target_coverage: 98.5
+  # Maximum values 
+  max_test_patterns: 0
 
 # Args for the "set_drc" command in TestMAX
 atpg.testmax.set_drc_args: [""]
 # Args for the "run_drc" command in TestMAX, the spf file is automatically taken after the synthesis step
 atpg.testmax.run_drc_args: [""]
 # Args for the "set_atpg" command in TestMAX
-atpg.testmax.set_atpg_args: ["-coverage", "98.5"]
+atpg.testmax.set_atpg_args: [""]
 # Args for the "run_atpg" command in TestMAX
 atpg.testmax.run_atpg_args: ["-auto_compression"]
 # Args for the "run_fault_sim" command in TestMAX

--- a/vlsi/example-designs/cnfet5-commercial.yml
+++ b/vlsi/example-designs/cnfet5-commercial.yml
@@ -21,46 +21,52 @@ vlsi.inputs.resets: [
 #       margins:
 #         right: 0  # or left: 0
 
-synthesis.dc.enable_congestion_map : true
+synthesis.enable_congestion_map : true
 
 # Design Compiler DFT insertion option
-synthesis.dc.dft_insertion : true 
+synthesis.dft_insertion : true 
 # Scan configuration 
-synthesis.dc.insert_dft.scan : true 
-synthesis.dc.dft.scan.style : "multiplexed_flip_flop" 
-synthesis.dc.dft.scan.chain_count : 1
-synthesis.dc.dft.scan.ports : [
+synthesis.insert_dft.scan : true 
+synthesis.dft.scan.style : "multiplexed_flip_flop" 
+synthesis.dft.scan.chain_count : 1
+synthesis.dft.scan.ports : [
   {"name" : "jtag_TDI" , "direction" : "in" , "type": "ScanDataIn"  ,"exist" : true },
   {"name" : "jtag_TDO" , "direction" : "out" , "type": "ScanDataOut"  ,"exist" : true }
 ]
-synthesis.dc.dft.scan.clock_ports: [
+synthesis.dft.scan.clock_ports: [
   {"name" : "jtag_TCK", "active_state" : "1", "timings" : ["45" , "95"] },
   {"name" : "clock_uncore", "active_state" : "1", "timings" : ["45" , "95"] },
   {"name" : "serial_tl_0_clock_in", "active_state" : "1", "timings" : ["45" , "95"] }
 ]
 
-synthesis.dc.dft.reset_ports : [
+synthesis.dft.reset_ports : [
   {"name" : "reset_io", "active_state" : "1"},
   {"name" : "jtag_reset", "active_state" : "1"},
 ]
 # BSD and JTAG
-synthesis.dc.insert_dft.bsd : false # TODO implement boundary scan insertion during the synthesis 
-synthesis.dc.dft.jtag.clk : "jtag_TCK"
-synthesis.dc.dft.jtag.tdi : "jtag_TDI"
-synthesis.dc.dft.jtag.tdo : "jtag_TDO"
-synthesis.dc.dft.jtag.tms : "jtag_TMS"
-synthesis.dc.dft.jtag.reset : "jtag_reset"
+synthesis.insert_dft.bsd : false # TODO implement boundary scan insertion during the synthesis 
+synthesis.dft.jtag.clk : "jtag_TCK"
+synthesis.dft.jtag.tdi : "jtag_TDI"
+synthesis.dft.jtag.tdo : "jtag_TDO"
+synthesis.dft.jtag.tms : "jtag_TMS"
+synthesis.dft.jtag.reset : "jtag_reset"
 # Memory Collar configuration 
-synthesis.dc.insert_dft.memory_wrapper : true 
+synthesis.insert_dft.memory_wrapper : true 
 # Scan compression configuration
-synthesis.dc.insert_dft.scan_compression : false # TODO implement scan compression insertion during the synthesis 
+synthesis.insert_dft.scan_compression : false # TODO implement scan compression insertion during the synthesis 
+
+# Set targeted fault coverage and number of generated test patterns from atpg
+atpg:
+  target_coverage: 98.5
+  # Maximum values 
+  max_test_patterns: 0
 
 # Args for the "set_drc" command in TestMAX
 atpg.testmax.set_drc_args: [""]
 # Args for the "run_drc" command in TestMAX, the spf file is automatically taken after the synthesis step
 atpg.testmax.run_drc_args: [""]
 # Args for the "set_atpg" command in TestMAX
-atpg.testmax.set_atpg_args: ["-coverage", "98.5"]
+atpg.testmax.set_atpg_args: [""]
 # Args for the "run_atpg" command in TestMAX
 atpg.testmax.run_atpg_args: ["-auto_compression"]
 # Args for the "run_fault_sim" command in TestMAX

--- a/vlsi/example-designs/cnfet7-commercial.yml
+++ b/vlsi/example-designs/cnfet7-commercial.yml
@@ -21,46 +21,52 @@ vlsi.inputs.resets: [
 #       margins:
 #         right: 0  # or left: 0
 
-synthesis.dc.enable_congestion_map : true
+synthesis.enable_congestion_map : true
 
 # Design Compiler DFT insertion option
-synthesis.dc.dft_insertion : true 
+synthesis.dft_insertion : true 
 # Scan configuration 
-synthesis.dc.insert_dft.scan : true 
-synthesis.dc.dft.scan.style : "multiplexed_flip_flop" 
-synthesis.dc.dft.scan.chain_count : 1
-synthesis.dc.dft.scan.ports : [
+synthesis.insert_dft.scan : true 
+synthesis.dft.scan.style : "multiplexed_flip_flop" 
+synthesis.dft.scan.chain_count : 1
+synthesis.dft.scan.ports : [
   {"name" : "jtag_TDI" , "direction" : "in" , "type": "ScanDataIn"  ,"exist" : true },
   {"name" : "jtag_TDO" , "direction" : "out" , "type": "ScanDataOut"  ,"exist" : true }
 ]
-synthesis.dc.dft.scan.clock_ports: [
+synthesis.dft.scan.clock_ports: [
   {"name" : "jtag_TCK", "active_state" : "1", "timings" : ["45" , "95"] },
   {"name" : "clock_uncore", "active_state" : "1", "timings" : ["45" , "95"] },
   {"name" : "serial_tl_0_clock_in", "active_state" : "1", "timings" : ["45" , "95"] }
 ]
 
-synthesis.dc.dft.reset_ports : [
+synthesis.dft.reset_ports : [
   {"name" : "reset_io", "active_state" : "1"},
   {"name" : "jtag_reset", "active_state" : "1"},
 ]
 # BSD and JTAG
-synthesis.dc.insert_dft.bsd : false # TODO implement boundary scan insertion during the synthesis 
-synthesis.dc.dft.jtag.clk : "jtag_TCK"
-synthesis.dc.dft.jtag.tdi : "jtag_TDI"
-synthesis.dc.dft.jtag.tdo : "jtag_TDO"
-synthesis.dc.dft.jtag.tms : "jtag_TMS"
-synthesis.dc.dft.jtag.reset : "jtag_reset"
+synthesis.insert_dft.bsd : false # TODO implement boundary scan insertion during the synthesis 
+synthesis.dft.jtag.clk : "jtag_TCK"
+synthesis.dft.jtag.tdi : "jtag_TDI"
+synthesis.dft.jtag.tdo : "jtag_TDO"
+synthesis.dft.jtag.tms : "jtag_TMS"
+synthesis.dft.jtag.reset : "jtag_reset"
 # Memory Collar configuration 
-synthesis.dc.insert_dft.memory_wrapper : true 
+synthesis.insert_dft.memory_wrapper : true 
 # Scan compression configuration
-synthesis.dc.insert_dft.scan_compression : false # TODO implement scan compression insertion during the synthesis 
+synthesis.insert_dft.scan_compression : false # TODO implement scan compression insertion during the synthesis 
+
+# Set targeted fault coverage and number of generated test patterns from atpg
+atpg:
+  target_coverage: 98.5
+  # Maximum values 
+  max_test_patterns: 0
 
 # Args for the "set_drc" command in TestMAX
 atpg.testmax.set_drc_args: [""]
 # Args for the "run_drc" command in TestMAX, the spf file is automatically taken after the synthesis step
 atpg.testmax.run_drc_args: [""]
 # Args for the "set_atpg" command in TestMAX
-atpg.testmax.set_atpg_args: ["-coverage", "98.5"]
+atpg.testmax.set_atpg_args: [""]
 # Args for the "run_atpg" command in TestMAX
 atpg.testmax.run_atpg_args: ["-auto_compression"]
 # Args for the "run_fault_sim" command in TestMAX

--- a/vlsi/example-designs/nangate15-commercial.yml
+++ b/vlsi/example-designs/nangate15-commercial.yml
@@ -19,46 +19,52 @@ vlsi.inputs.resets: [
 #       margins:
 #         right: 0  # or left: 0
 
-synthesis.dc.enable_congestion_map : true
+synthesis.enable_congestion_map : true
 
 # Design Compiler DFT insertion option
-synthesis.dc.dft_insertion : true 
+synthesis.dft_insertion : true 
 # Scan configuration 
-synthesis.dc.insert_dft.scan : true 
-synthesis.dc.dft.scan.style : "multiplexed_flip_flop" 
-synthesis.dc.dft.scan.chain_count : 1
-synthesis.dc.dft.scan.ports : [
+synthesis.insert_dft.scan : true 
+synthesis.dft.scan.style : "multiplexed_flip_flop" 
+synthesis.dft.scan.chain_count : 1
+synthesis.dft.scan.ports : [
   {"name" : "jtag_TDI" , "direction" : "in" , "type": "ScanDataIn"  ,"exist" : true },
   {"name" : "jtag_TDO" , "direction" : "out" , "type": "ScanDataOut"  ,"exist" : true }
 ]
-synthesis.dc.dft.scan.clock_ports: [
+synthesis.dft.scan.clock_ports: [
   {"name" : "jtag_TCK", "active_state" : "1", "timings" : ["45" , "95"] },
   {"name" : "clock_uncore", "active_state" : "1", "timings" : ["45" , "95"] },
 #  {"name" : "serial_tl_0_clock_in", "active_state" : "1", "timings" : ["45" , "95"] }
 ]
 
-synthesis.dc.dft.reset_ports : [
+synthesis.dft.reset_ports : [
   {"name" : "reset_io", "active_state" : "1"},
   {"name" : "jtag_reset", "active_state" : "1"},
 ]
 # BSD and JTAG
-synthesis.dc.insert_dft.bsd : false # TODO implement boundary scan insertion during the synthesis 
-synthesis.dc.dft.jtag.clk : "jtag_TCK"
-synthesis.dc.dft.jtag.tdi : "jtag_TDI"
-synthesis.dc.dft.jtag.tdo : "jtag_TDO"
-synthesis.dc.dft.jtag.tms : "jtag_TMS"
-synthesis.dc.dft.jtag.reset : "jtag_reset"
+synthesis.insert_dft.bsd : false # TODO implement boundary scan insertion during the synthesis 
+synthesis.dft.jtag.clk : "jtag_TCK"
+synthesis.dft.jtag.tdi : "jtag_TDI"
+synthesis.dft.jtag.tdo : "jtag_TDO"
+synthesis.dft.jtag.tms : "jtag_TMS"
+synthesis.dft.jtag.reset : "jtag_reset"
 # Memory Collar configuration 
-synthesis.dc.insert_dft.memory_wrapper : true 
+synthesis.insert_dft.memory_wrapper : true 
 # Scan compression configuration
-synthesis.dc.insert_dft.scan_compression : false # TODO implement scan compression insertion during the synthesis 
+synthesis.insert_dft.scan_compression : false # TODO implement scan compression insertion during the synthesis 
+
+# Set targeted fault coverage and number of generated test patterns from atpg
+atpg:
+  target_coverage: 98.5
+  # Maximum values 
+  max_test_patterns: 0
 
 # Args for the "set_drc" command in TestMAX
 atpg.testmax.set_drc_args: [""]
 # Args for the "run_drc" command in TestMAX, the spf file is automatically taken after the synthesis step
 atpg.testmax.run_drc_args: [""]
 # Args for the "set_atpg" command in TestMAX
-atpg.testmax.set_atpg_args: ["-coverage", "98.5"]
+atpg.testmax.set_atpg_args: [""]
 # Args for the "run_atpg" command in TestMAX
 atpg.testmax.run_atpg_args: ["-auto_compression"]
 # Args for the "run_fault_sim" command in TestMAX

--- a/vlsi/example-designs/nangate45-commercial.yml
+++ b/vlsi/example-designs/nangate45-commercial.yml
@@ -21,46 +21,52 @@ vlsi.inputs.resets: [
 #       margins:
 #         right: 0  # or left: 0
 
-synthesis.dc.enable_congestion_map : true
+synthesis.enable_congestion_map : true
 
 # Design Compiler DFT insertion option
-synthesis.dc.dft_insertion : true 
+synthesis.dft_insertion : true 
 # Scan configuration 
-synthesis.dc.insert_dft.scan : true 
-synthesis.dc.dft.scan.style : "multiplexed_flip_flop" 
-synthesis.dc.dft.scan.chain_count : 1
-synthesis.dc.dft.scan.ports : [
+synthesis.insert_dft.scan : true 
+synthesis.dft.scan.style : "multiplexed_flip_flop" 
+synthesis.dft.scan.chain_count : 1
+synthesis.dft.scan.ports : [
   {"name" : "jtag_TDI" , "direction" : "in" , "type": "ScanDataIn"  ,"exist" : true },
   {"name" : "jtag_TDO" , "direction" : "out" , "type": "ScanDataOut"  ,"exist" : true }
 ]
-synthesis.dc.dft.scan.clock_ports: [
+synthesis.dft.scan.clock_ports: [
   {"name" : "jtag_TCK", "active_state" : "1", "timings" : ["45" , "95"] },
   {"name" : "clock_uncore", "active_state" : "1", "timings" : ["45" , "95"] },
   {"name" : "serial_tl_0_clock_in", "active_state" : "1", "timings" : ["45" , "95"] }
 ]
 
-synthesis.dc.dft.reset_ports : [
+synthesis.dft.reset_ports : [
   {"name" : "reset_io", "active_state" : "1"},
   {"name" : "jtag_reset", "active_state" : "1"},
 ]
 # BSD and JTAG
-synthesis.dc.insert_dft.bsd : false # TODO implement boundary scan insertion during the synthesis 
-synthesis.dc.dft.jtag.clk : "jtag_TCK"
-synthesis.dc.dft.jtag.tdi : "jtag_TDI"
-synthesis.dc.dft.jtag.tdo : "jtag_TDO"
-synthesis.dc.dft.jtag.tms : "jtag_TMS"
-synthesis.dc.dft.jtag.reset : "jtag_reset"
+synthesis.insert_dft.bsd : false # TODO implement boundary scan insertion during the synthesis 
+synthesis.dft.jtag.clk : "jtag_TCK"
+synthesis.dft.jtag.tdi : "jtag_TDI"
+synthesis.dft.jtag.tdo : "jtag_TDO"
+synthesis.dft.jtag.tms : "jtag_TMS"
+synthesis.dft.jtag.reset : "jtag_reset"
 # Memory Collar configuration 
-synthesis.dc.insert_dft.memory_wrapper : true 
+synthesis.insert_dft.memory_wrapper : true 
 # Scan compression configuration
-synthesis.dc.insert_dft.scan_compression : false # TODO implement scan compression insertion during the synthesis 
+synthesis.insert_dft.scan_compression : false # TODO implement scan compression insertion during the synthesis 
+
+# Set targeted fault coverage and number of generated test patterns from atpg
+atpg:
+  target_coverage: 98.5
+  # Maximum values 
+  max_test_patterns: 0
 
 # Args for the "set_drc" command in TestMAX
 atpg.testmax.set_drc_args: [""]
 # Args for the "run_drc" command in TestMAX, the spf file is automatically taken after the synthesis step
 atpg.testmax.run_drc_args: [""]
 # Args for the "set_atpg" command in TestMAX
-atpg.testmax.set_atpg_args: ["-coverage", "98.5"]
+atpg.testmax.set_atpg_args: [""]
 # Args for the "run_atpg" command in TestMAX
 atpg.testmax.run_atpg_args: ["-auto_compression"]
 # Args for the "run_fault_sim" command in TestMAX


### PR DESCRIPTION
This pull request refactors the DFT (Design-for-Test) and ATPG (Automatic Test Pattern Generation) configuration sections in several example design YAML files to standardize key names and improve clarity. It removes the `dc.` (Design Compiler) prefix from all synthesis-related configuration keys, consolidates DFT settings, and introduces a new `atpg` section for fault coverage and test pattern settings.

Key changes include:

**Standardization and Refactoring of Synthesis and DFT Configuration:**

- Removed the `dc.` prefix from all synthesis and DFT-related keys (e.g., `synthesis.dc.dft_insertion` → `synthesis.dft_insertion`, `synthesis.dc.insert_dft.scan` → `synthesis.insert_dft.scan`) for consistency and tool-agnostic configuration. [[1]](diffhunk://#diff-3e8acc905382de5bd8f6fb6ae42334ea2f7511c6ea91197998f50a2560ea8113L89-R130) [[2]](diffhunk://#diff-e1c6588ef6f137bda35e091eae3c4f511ca391d0e8093102fced0ee10beaaa7bL24-R69) [[3]](diffhunk://#diff-93b63db6c926e5f33cf5ae054ea46ba60e9b7786fbe5399c57fb7c773cd499c1L22-R67)

- Updated all DFT scan, clock, reset, memory wrapper, BSD, JTAG, and scan compression settings to use the new standardized key names across all affected design files. [[1]](diffhunk://#diff-3e8acc905382de5bd8f6fb6ae42334ea2f7511c6ea91197998f50a2560ea8113L89-R130) [[2]](diffhunk://#diff-e1c6588ef6f137bda35e091eae3c4f511ca391d0e8093102fced0ee10beaaa7bL24-R69) [[3]](diffhunk://#diff-93b63db6c926e5f33cf5ae054ea46ba60e9b7786fbe5399c57fb7c773cd499c1L22-R67)

**ATPG Configuration Enhancements:**

- Added a new `atpg` section with `target_coverage` and `max_test_patterns` fields to explicitly specify desired fault coverage and test pattern limits for ATPG tools. [[1]](diffhunk://#diff-3e8acc905382de5bd8f6fb6ae42334ea2f7511c6ea91197998f50a2560ea8113L89-R130) [[2]](diffhunk://#diff-e1c6588ef6f137bda35e091eae3c4f511ca391d0e8093102fced0ee10beaaa7bL24-R69) [[3]](diffhunk://#diff-93b63db6c926e5f33cf5ae054ea46ba60e9b7786fbe5399c57fb7c773cd499c1L22-R67)

- Changed default `atpg.testmax.set_atpg_args` from a hardcoded coverage value to an empty string, delegating coverage specification to the new `atpg.target_coverage` field. [[1]](diffhunk://#diff-3e8acc905382de5bd8f6fb6ae42334ea2f7511c6ea91197998f50a2560ea8113L89-R130) [[2]](diffhunk://#diff-e1c6588ef6f137bda35e091eae3c4f511ca391d0e8093102fced0ee10beaaa7bL24-R69) [[3]](diffhunk://#diff-93b63db6c926e5f33cf5ae054ea46ba60e9b7786fbe5399c57fb7c773cd499c1L22-R67)

**Other Configuration Improvements:**

- Standardized the congestion map enable key from `synthesis.dc.enable_congestion_map` to `synthesis.enable_congestion_map` for consistency. [[1]](diffhunk://#diff-e1c6588ef6f137bda35e091eae3c4f511ca391d0e8093102fced0ee10beaaa7bL24-R69) [[2]](diffhunk://#diff-93b63db6c926e5f33cf5ae054ea46ba60e9b7786fbe5399c57fb7c773cd499c1L22-R67)

These changes make the configuration files more maintainable, easier to read, and less tool-specific, paving the way for improved automation and portability.