### PR TITLE
Fix: ibex core 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,7 @@
 	url = https://github.com/ucb-bar/berkeley-hardfloat.git
 [submodule "generators/ibex"]
 	path = generators/ibex
-	url = https://github.com/ucb-bar/ibex-wrapper.git
+	url = https://github.com/cad-polito-it/ibex-wrapper.git
 [submodule "generators/icenet"]
 	path = generators/icenet
 	url = https://github.com/firesim/icenet.git
@@ -60,7 +60,7 @@
 	url = https://github.com/ucb-bar/shuttle.git
 [submodule "generators/testchipip"]
 	path = generators/testchipip
-	url = https://github.com/ucb-bar/testchipip.git
+	url = https://github.com/cad-polito-it/testchipip.git
 [submodule "sims/firesim"]
 	path = sims/firesim
 	url = https://github.com/firesim/firesim.git

--- a/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
@@ -173,6 +173,16 @@ class WithRadBootROM(address: BigInt = 0x10000, size: Int = 0x10000, hang: BigIn
     ))
 })
 
+class WithIbexBootROM(address: BigInt = 0x10000, size: Int = 0x10000, hang: BigInt = 0x10000) extends Config((site, here, up) => {
+  case BootROMLocated(x) => up(BootROMLocated(x))
+    .map(_.copy(
+      address = address,
+      size = size,
+      hang = hang,
+      contentFileName = ResourceFileName(s"/testchipip/bootrom/bootrom.ibex.rv32.img")
+    ))
+})
+
 class WithNoBusErrorDevices extends Config((site, here, up) => {
   case SystemBusKey => up(SystemBusKey).copy(errorDevice = None)
   case ControlBusKey => up(ControlBusKey).copy(errorDevice = None)

--- a/scripts/build-toolchain-extra.sh
+++ b/scripts/build-toolchain-extra.sh
@@ -100,6 +100,7 @@ echo '==> Installing espresso logic minimizer'
 
 echo '==>  Installing libgloss'
 CC= CXX= SRCDIR="$(pwd)/toolchains" module_all libgloss --prefix="${RISCV}/riscv${XLEN}-unknown-elf" --host=riscv${XLEN}-unknown-elf
+cd $(pwd)/toolchain/libgloss && mkdir build-32 && cd build-32 && ../configure --prefix=${RISCV}/riscv64-unknown-elf --host=riscv64-unknown-elf --enable-multilib='rv32imc_zicsr/ilp32' && make CFLAGS_FOR_TARGET="-march=rv32imc_zicsr -mabi=ilp32"
 
 cd $RDIR
 if [ $TOOLCHAIN == "riscv-tools" ]; then

--- a/scripts/build-toolchain-extra.sh
+++ b/scripts/build-toolchain-extra.sh
@@ -100,7 +100,7 @@ echo '==> Installing espresso logic minimizer'
 
 echo '==>  Installing libgloss'
 CC= CXX= SRCDIR="$(pwd)/toolchains" module_all libgloss --prefix="${RISCV}/riscv${XLEN}-unknown-elf" --host=riscv${XLEN}-unknown-elf
-cd $(pwd)/toolchain/libgloss && mkdir build-32 && cd build-32 && ../configure --prefix=${RISCV}/riscv64-unknown-elf --host=riscv64-unknown-elf --enable-multilib='rv32imc_zicsr/ilp32' && make CFLAGS_FOR_TARGET="-march=rv32imc_zicsr -mabi=ilp32"
+cd "$(pwd)/toolchains/libgloss" && mkdir -p build-32 && cd build-32 && ../configure --prefix="${RISCV}/riscv64-unknown-elf" --host=riscv64-unknown-elf --enable-multilib='rv32imc_zicsr/ilp32' && make CFLAGS_FOR_TARGET="-march=rv32imc_zicsr -mabi=ilp32"
 
 cd $RDIR
 if [ $TOOLCHAIN == "riscv-tools" ]; then

--- a/tests/ibex/CMakeLists.txt
+++ b/tests/ibex/CMakeLists.txt
@@ -21,6 +21,14 @@ project(chipyard-tests LANGUAGES C CXX ASM)
 set(CMAKE_SYSTEM_NAME         "Generic" CACHE STRING "")
 set(CMAKE_SYSTEM_PROCESSOR    "riscv"   CACHE STRING "")
 
+if(NOT DEFINED ENV{CY_DIR})
+  message(FATAL_ERROR "CY_DIR environment variable must be set to the Chipyard repo root (export CY_DIR).")
+endif()
+
+if(NOT DEFINED ENV{RISCV_32})
+  message(FATAL_ERROR "RISCV_32 environment variable must be set to the RISCV-32 toolchain root.")
+endif()
+
 set(TOOLCHAIN_PREFIX    "${RISCV_32}/riscv64-unknown-elf-")
 
 set(CMAKE_AR            "${TOOLCHAIN_PREFIX}ar")
@@ -46,24 +54,24 @@ set(CMODEL              "medany")
 set(ARCH_FLAGS          -march=${ARCH} -mabi=${ABI} -mcmodel=${CMODEL})
 
 # spec
-set(SPECS               "${CY_DIR}/toolchains/libgloss/util/htif_nano.specs")
+set(SPECS               "$ENV{CY_DIR}/toolchains/libgloss/util/htif_nano.specs")
 set(SPEC_FLAGS          -specs=${SPECS})
 
 # linker script
-set(LINKER_SCRIPT       "${CY_DIR}/tests/htif.ld")
+set(LINKER_SCRIPT       "$ENV{CY_DIR}/tests/htif.ld")
 
 add_compile_options(-std=gnu99)
 add_compile_options(-O2 -Wall -Wextra)
 add_compile_options(-fno-common -fno-builtin-printf)
 add_compile_options(${ARCH_FLAGS})
 add_compile_options(${SPEC_FLAGS})
-add_compile_options("-I${CY_DIR}/toolchains/riscv-tools/riscv-pk/machine")
+add_compile_options("-I$ENV{CY_DIR}/toolchains/riscv-tools/riscv-pk/machine")
 add_link_options(-static)
 add_link_options(${SPEC_FLAGS})
 add_link_options(-T ${LINKER_SCRIPT})
 add_link_options(${ARCH_FLAGS})
 add_link_options(${SPEC_FLAGS})
-add_link_options("-L${CY_DIR}/toolchains/libgloss/build-32/rv32imc_zicsr/ilp32/")
+add_link_options("-L$ENV{CY_DIR}/toolchains/libgloss/build-32/rv32imc_zicsr/ilp32/")
 
 
 #################################

--- a/tests/ibex/CMakeLists.txt
+++ b/tests/ibex/CMakeLists.txt
@@ -11,7 +11,7 @@
 ########################################################################################################################
 cmake_minimum_required(VERSION 3.10)
 
-project(chipyard-tests LANGUAGES C CXX ASM)
+project(chipyard-tests-ibex LANGUAGES C CXX ASM)
 
 
 #################################
@@ -21,7 +21,7 @@ project(chipyard-tests LANGUAGES C CXX ASM)
 set(CMAKE_SYSTEM_NAME         "Generic" CACHE STRING "")
 set(CMAKE_SYSTEM_PROCESSOR    "riscv"   CACHE STRING "")
 
-set(TOOLCHAIN_PREFIX    "${RISCV_32}/riscv64-unknown-elf-")
+set(TOOLCHAIN_PREFIX    "$ENV{RISCV_32}/riscv64-unknown-elf-")
 
 set(CMAKE_AR            "${TOOLCHAIN_PREFIX}ar")
 set(CMAKE_ASM_COMPILER  "${TOOLCHAIN_PREFIX}gcc")
@@ -46,24 +46,24 @@ set(CMODEL              "medany")
 set(ARCH_FLAGS          -march=${ARCH} -mabi=${ABI} -mcmodel=${CMODEL})
 
 # spec
-set(SPECS               "${CY_DIR}/toolchains/libgloss/util/htif_nano.specs")
+set(SPECS               "$ENV{CY_DIR}/toolchains/libgloss/util/htif_nano.specs")
 set(SPEC_FLAGS          -specs=${SPECS})
 
 # linker script
-set(LINKER_SCRIPT       "${CY_DIR}/tests/htif.ld")
+set(LINKER_SCRIPT       "$ENV{CY_DIR}/tests/htif.ld")
 
 add_compile_options(-std=gnu99)
 add_compile_options(-O2 -Wall -Wextra)
 add_compile_options(-fno-common -fno-builtin-printf)
 add_compile_options(${ARCH_FLAGS})
 add_compile_options(${SPEC_FLAGS})
-add_compile_options("-I${CY_DIR}/toolchains/riscv-tools/riscv-pk/machine")
+add_compile_options("-I$ENV{CY_DIR}/toolchains/riscv-tools/riscv-pk/machine")
 add_link_options(-static)
 add_link_options(${SPEC_FLAGS})
 add_link_options(-T ${LINKER_SCRIPT})
 add_link_options(${ARCH_FLAGS})
 add_link_options(${SPEC_FLAGS})
-add_link_options("-L${CY_DIR}/toolchains/libgloss/build-32/rv32imc_zicsr/ilp32/")
+add_link_options("-L$ENV{CY_DIR}/toolchains/libgloss/build-32/rv32imc_zicsr/ilp32/")
 
 
 #################################

--- a/tests/ibex/CMakeLists.txt
+++ b/tests/ibex/CMakeLists.txt
@@ -1,0 +1,94 @@
+########################################################################################################################
+# file:  CMakeLists.txt
+#
+# usage: 
+#   Edit "VARIABLES"-section to suit project requirements.
+#   Build instructions:
+#     cmake -S ./ -B ./build/ -D CMAKE_BUILD_TYPE=Debug
+#     cmake --build ./build/ --target all
+#   Cleaning:
+#     cmake --build ./build/ --target clean
+########################################################################################################################
+cmake_minimum_required(VERSION 3.10)
+
+project(chipyard-tests LANGUAGES C CXX ASM)
+
+
+#################################
+# RISCV Toolchain
+#################################
+
+set(CMAKE_SYSTEM_NAME         "Generic" CACHE STRING "")
+set(CMAKE_SYSTEM_PROCESSOR    "riscv"   CACHE STRING "")
+
+set(TOOLCHAIN_PREFIX    "${RISCV_32}/riscv64-unknown-elf-")
+
+set(CMAKE_AR            "${TOOLCHAIN_PREFIX}ar")
+set(CMAKE_ASM_COMPILER  "${TOOLCHAIN_PREFIX}gcc")
+set(CMAKE_C_COMPILER    "${TOOLCHAIN_PREFIX}gcc")
+set(CMAKE_CXX_COMPILER  "${TOOLCHAIN_PREFIX}g++")
+set(CMAKE_LINKER        "${TOOLCHAIN_PREFIX}ld")
+set(CMAKE_OBJCOPY       "${TOOLCHAIN_PREFIX}objcopy")
+set(CMAKE_OBJDUMP       "${TOOLCHAIN_PREFIX}objdump")
+set(CMAKE_SIZE          "${TOOLCHAIN_PREFIX}size")
+
+set(CMAKE_EXECUTABLE_SUFFIX            ".riscv")
+
+
+#################################
+# Flags
+#################################
+
+# CPU architecture
+set(ARCH                "rv32imc_zicsr")
+set(ABI                 "ilp32")
+set(CMODEL              "medany")
+set(ARCH_FLAGS          -march=${ARCH} -mabi=${ABI} -mcmodel=${CMODEL})
+
+# spec
+set(SPECS               "${CY_DIR}/toolchains/libgloss/util/htif_nano.specs")
+set(SPEC_FLAGS          -specs=${SPECS})
+
+# linker script
+set(LINKER_SCRIPT       "${CY_DIR}/tests/htif.ld")
+
+add_compile_options(-std=gnu99)
+add_compile_options(-O2 -Wall -Wextra)
+add_compile_options(-fno-common -fno-builtin-printf)
+add_compile_options(${ARCH_FLAGS})
+add_compile_options(${SPEC_FLAGS})
+add_compile_options("-I${CY_DIR}/toolchains/riscv-tools/riscv-pk/machine")
+add_link_options(-static)
+add_link_options(${SPEC_FLAGS})
+add_link_options(-T ${LINKER_SCRIPT})
+add_link_options(${ARCH_FLAGS})
+add_link_options(${SPEC_FLAGS})
+add_link_options("-L${CY_DIR}/toolchains/libgloss/build-32/rv32imc_zicsr/ilp32/")
+
+
+#################################
+# Build
+#################################
+
+add_executable(hello hello.c)
+
+#################################
+# Disassembly
+#################################
+
+# Add a target to generate all disassemblies
+add_custom_target(dump ALL)
+
+# Function to add disassembly target for an executable
+function(add_dump_target target_name)
+    add_custom_target(${target_name}-dump
+        BYPRODUCTS ${CMAKE_BINARY_DIR}/${target_name}.dump
+        COMMAND ${CMAKE_OBJDUMP} -D $<TARGET_FILE:${target_name}> > ${CMAKE_BINARY_DIR}/${target_name}.dump
+        DEPENDS ${target_name}
+        COMMENT "Generating disassembly for ${target_name}"
+    )
+    add_dependencies(${target_name}-dump ${target_name})
+    add_dependencies(dump ${target_name}-dump)
+endfunction()
+
+add_dump_target(hello)

--- a/tests/ibex/hello.c
+++ b/tests/ibex/hello.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include "encoding.h"
+#include <stdint.h>
+
+int main(void) {
+  printf("Hello world\n");
+  return 0;
+}

--- a/vlsi/.gitignore
+++ b/vlsi/.gitignore
@@ -5,6 +5,7 @@ build
 build-*
 src/test/output-*.json
 generated-src
+generated-src-*
 output.json
 output
 

--- a/vlsi/vlsi-ibex
+++ b/vlsi/vlsi-ibex
@@ -65,7 +65,7 @@ def insert_internal_memory_collar(x: HammerTool) -> bool:
         x.append("identify_clock_gating")
         x.append("set_dft_clock_gating_pin {system/tile_prci_domain/element_reset_domain_ibex_tile/core/i_ibex/core_clock_gate_i} -pin_name test_en_i -control_signal TestMode")
         x.append("set_testability_configuration -target random_resistant")
-        x.append("set_testability_configuration -targetx_blocking")
+        x.append("set_testability_configuration -target x_blocking")
         x.append("set_testability_configuration -target multicycle_paths")
         x.append("set_testability_configuration -target atpg_conflict")
         x.append("set_test_assume 1 system/tile_prci_domain/element_reset_domain_ibex_tile/core/i_ibex/core_clock_gate_i")

--- a/vlsi/vlsi-ibex
+++ b/vlsi/vlsi-ibex
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
+#
+# NOTE: this ExampleDriver works for Ibex ONLY. 
 
 import os
 
 from hammer.vlsi import CLIDriver, HammerTool, HammerToolHookAction
+from hammer.tech.specialcells import CellType
+
 
 from typing import Dict, Callable, Optional, List
 
@@ -11,35 +15,99 @@ def add_options(x: HammerTool) -> bool:
         # Needed by design compiler because asap7 has no three state cells
         if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
             x.append("set_app_var compile_assume_fully_decoded_three_state_busses true")
+    if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
+        x.append("set_app_var compile_seqmap_no_scan_cell true")
+        x.append("set_app_var compile_seqmap_identify_shift_registers false")
+        x.append("set_app_var test_validate_test_model_connectivity true")
     return True 
 
 
 def connect_black_box_signals(x: HammerTool) -> bool:
-    if x.get_setting("vlsi.core.technology") == "hammer.technology.asap7":
-            if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
-                # Connect top level black box's signals (unconnected) to scan signals
-                x.append("disconnect_net [all_connected system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i] system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i")
-                x.append("connect_pin -from [get_port test_mode]  -to system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i  -port_name test_en_i_core")    
-                x.append("disconnect_net [all_connected system/tile_prci_domain/element_reset_domain_ibex_tile/core/scan_rst_ni] system/tile_prci_domain/element_reset_domain_ibex_tile/core/scan_rst_ni")
-                x.append("connect_pin -from [get_port test_mode] -to system/tile_prci_domain/element_reset_domain_ibex_tile/core/scan_rst_ni  -port_name scan_rst_ni_core")    
+    if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
+        # Connect top level black box's signals (unconnected) to scan signals
+        x.append("create_port test_mode") # Create a virtual testmode port Hammer will specify this later
+        x.append("set pin [get_pins system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i]")
+        x.append("disconnect_net [all_connected $pin] $pin")
+        x.append("connect_pin -from [get_port test_mode]  -to $pin  -port_name test_mode_i_core")    
+        
+        x.append("set pin [get_pins system/tile_prci_domain/element_reset_domain_ibex_tile/core/scan_rst_ni]")
+        x.append("disconnect_net [all_connected $pin] $pin")
+        # Create inverter cell with highest strength
+        gate_cells = x.technology.get_special_cell_by_type(CellType.CTSInverter)
+        if len(gate_cells) > 0:
+            selected_cell = gate_cells[-1].name[-1]
+            # Inverters have single i/os
+            input = gate_cells[-1].input_ports[-1]
+            output = gate_cells[-1].output_ports[-1]
+            x.append(f"create_cell system/tile_prci_domain/element_reset_domain_ibex_tile/inv_rst  {x.technology.config.name}/{selected_cell}")
+            x.append(f"connect_pin -from [get_port test_mode]  -to system/tile_prci_domain/element_reset_domain_ibex_tile/inv_rst/{input}  -port_name scan_rst_core_i")    
+            x.append(f"connect_pin -from system/tile_prci_domain/element_reset_domain_ibex_tile/inv_rst/{output} -to $pin  -port_name scan_rst_ni_core_i")    
+        else:
+            x.logger.error("Current technology does not have any definitions for inverter cells")
+        x.append("set test_keep_connected_scan_en true")
     return True 
 
 
 def connect_clk_en_reg(x: HammerTool) -> bool:
     if x.get_setting("vlsi.core.technology") == "hammer.technology.asap7":
+        x.append("set test_fix_bus true")
         if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
             x.append("disconnect_net [all_connected clock_en_reg/RESET] clock_en_reg/RESET")
             x.append("connect_pin -from [get_nets n_debug_reset_syncd_debug_reset_sync_io_q ] -to clock_en_reg/RESET ")
-            x.append("connect_pin -from  [get_ports test_mode] -to [get_nets system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i] ")    
-            x.append("set test_fix_bus true")
     return True
     
+
+
+def insert_internal_memory_collar(x: HammerTool) -> bool:
+    if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
+        if x.get_setting("synthesis.insert_dft.memory_wrapper"):
+            x.append(x.insert_test_points(["\"*prim_ram_1p*\"", "\"prim_clock_gating\""]))
+        x.append("identify_clock_gating")
+        x.append("set_dft_clock_gating_pin {system/tile_prci_domain/element_reset_domain_ibex_tile/core/i_ibex/core_clock_gate_i} -pin_name test_en_i -control_signal TestMode")
+        x.append("set_testability_configuration -target random_resistant")
+        x.append("set_testability_configuration -targetx_blocking")
+        x.append("set_testability_configuration -target multicycle_paths")
+        x.append("set_testability_configuration -target atpg_conflict")
+        x.append("set_test_assume 1 system/tile_prci_domain/element_reset_domain_ibex_tile/core/i_ibex/core_clock_gate_i")
+        x.append("set_test_assume 1 system/tile_prci_domain/element_reset_domain_ibex_tile/core/i_ibex/core_clock_gate_i")
+        x.append("set_dft_signal -view spec -type TestMode -port test_mode -active_state 1 -connect_to system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i")
+    return True
+
+def add_black_boxes(x: HammerTool) -> bool:
+    if x.get_setting("vlsi.core.synthesis_tool") == "hammer.synthesis.dc":
+      x.append("foreach_in_collection ram [get_references -hierarchical \"*prim_ram_1p*\"] {")
+      x.append("set_attribute $ram is_memory_cell true")
+      x.append("set_attribute $ram is_physical_black_box true" )
+      x.append("set_dont_touch $ram")
+      x.append("}")
+    return True 
+
+def insert_nofaults_modules(x: HammerTool) -> bool:
+    # Do not add faults around the following modules
+    x.additional_modules = [".*prim_ram_1p.*"]
+    return True
+
+def add_constraints(x: HammerTool) -> bool:
+    # x.append("add_pi_constraints 1 test_mode")
+    # x.append("add_pi_constraints 1 test_se")
+    return True
+
 class ExampleDriver(CLIDriver):
     def get_extra_synthesis_hooks(self) -> List[HammerToolHookAction]:
         extra_hooks = [
             HammerTool.make_post_insertion_hook("init_environment", add_options),
+            HammerTool.make_post_insertion_hook("elaborate_design", add_black_boxes),
             HammerTool.make_pre_insertion_hook("configure_dft", connect_clk_en_reg),
-            HammerTool.make_post_insertion_hook("configure_dft", connect_black_box_signals),
+            HammerTool.make_pre_insertion_hook("configure_dft", connect_black_box_signals),
+            HammerTool.make_post_insertion_hook("configure_dft", insert_internal_memory_collar)
+
+        ]
+        return extra_hooks
+
+    def get_extra_atpg_hooks(self) -> List[HammerToolHookAction]:
+        extra_hooks = [
+            HammerTool.make_pre_insertion_hook("run_drc", add_constraints),
+            HammerTool.make_pre_insertion_hook("run_atpg", insert_nofaults_modules)
         ]
         return extra_hooks
 

--- a/vlsi/vlsi-ibex
+++ b/vlsi/vlsi-ibex
@@ -69,7 +69,6 @@ def insert_internal_memory_collar(x: HammerTool) -> bool:
         x.append("set_testability_configuration -target multicycle_paths")
         x.append("set_testability_configuration -target atpg_conflict")
         x.append("set_test_assume 1 system/tile_prci_domain/element_reset_domain_ibex_tile/core/i_ibex/core_clock_gate_i")
-        x.append("set_test_assume 1 system/tile_prci_domain/element_reset_domain_ibex_tile/core/i_ibex/core_clock_gate_i")
         x.append("set_dft_signal -view spec -type TestMode -port test_mode -active_state 1 -connect_to system/tile_prci_domain/element_reset_domain_ibex_tile/core/test_en_i")
     return True
 


### PR DESCRIPTION
This pull request introduces significant improvements to Ibex core support in the project, including new build/test infrastructure, enhanced VLSI flow customization for Ibex, and updates to submodule sources. The main changes are the addition of a CMake-based build system and example test for Ibex, extensive enhancements to the VLSI flow for Ibex-specific synthesis and DFT, and updates to submodule URLs and commits to use custom forks.

**Ibex Build and Test Infrastructure:**

- Added a new `CMakeLists.txt` and a simple `hello.c` test program under `tests/ibex`, enabling standalone building and disassembly of Ibex-targeted tests using the RISCV toolchain. [[1]](diffhunk://#diff-60a22fe187322d70b94c3d52d5a5f80185cc5d402b66f26056491605e21d28ecR1-R94) [[2]](diffhunk://#diff-30d4dc0204f6290d61ab605ea32b0253d2d25f41a2a459823ba370685cd2ce45R1-R8)
- Updated the `build-toolchain-extra.sh` script to build `libgloss` with RV32IMC multilib support, required for Ibex software tests.

**Ibex Boot ROM and Configuration:**

- Introduced the `WithIbexBootROM` config fragment in `PeripheralFragments.scala` to allow easy selection of a boot ROM image compatible with Ibex.

**VLSI Flow Enhancements for Ibex:**

- Major extension of `vlsi/vlsi-ibex` to add Ibex-specific hooks for synthesis, DFT, black box handling, scan chain connections, and clock gating, leveraging Hammer's hook system and technology cell introspection. [[1]](diffhunk://#diff-44fad04143bb69c337434d7dd2e86fdaa2b307d9656e7f9a6f8a4921c4444f5cR2-R9) [[2]](diffhunk://#diff-44fad04143bb69c337434d7dd2e86fdaa2b307d9656e7f9a6f8a4921c4444f5cR18-R110)

**Submodule Source and Commit Updates:**

- Changed the `ibex-wrapper` and `testchipip` submodules in `.gitmodules` to point to `cad-polito-it` forks instead of the upstream `ucb-bar` repositories. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L33-R33) [[2]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L63-R63)
- Updated the `ibex` and `testchipip` submodule commits to new SHAs, likely to match the forks or include new features. [[1]](diffhunk://#diff-f5727b96eb93e165bf85476e11b68f110305cff3db38d584b0715e059470ae00L1-R1) [[2]](diffhunk://#diff-194276bb6deb6fdf57c4d44cab7264807e4e57a8c3f8041d15a9cab612860e4aL1-R1)

These changes collectively improve Ibex integration, testability, and build reproducibility within the project.

**References:**
- [[1]](diffhunk://#diff-60a22fe187322d70b94c3d52d5a5f80185cc5d402b66f26056491605e21d28ecR1-R94) [[2]](diffhunk://#diff-30d4dc0204f6290d61ab605ea32b0253d2d25f41a2a459823ba370685cd2ce45R1-R8) [[3]](diffhunk://#diff-4d57904571a9165bc82f8052a556ea903713c75a6ff584b7ef4660a283abf9b4R103) [[4]](diffhunk://#diff-82e7e16a25c57ca7a40c4874b23de840eb51093ea096423acf45c70c60dbc19eR176-R185) [[5]](diffhunk://#diff-44fad04143bb69c337434d7dd2e86fdaa2b307d9656e7f9a6f8a4921c4444f5cR2-R9) [[6]](diffhunk://#diff-44fad04143bb69c337434d7dd2e86fdaa2b307d9656e7f9a6f8a4921c4444f5cR18-R110) [[7]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L33-R33) [[8]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L63-R63) [[9]](diffhunk://#diff-f5727b96eb93e165bf85476e11b68f110305cff3db38d584b0715e059470ae00L1-R1) [[10]](diffhunk://#diff-194276bb6deb6fdf57c4d44cab7264807e4e57a8c3f8041d15a9cab612860e4aL1-R1)